### PR TITLE
Feature: Improve docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.19.3
+
+- Make `String.Join` more composable with other list types.
+
 ## 0.19.2
 
 - Improve `NaturalNumber.Multiply` and `Combinator.FixSequence` performance.

--- a/prompts/chatgpt/package.json
+++ b/prompts/chatgpt/package.json
@@ -18,7 +18,7 @@
   "author": "Mike <admin@code.lol>",
   "license": "MIT",
   "dependencies": {
-    "chatgpt": "^4.1.1"
+    "chatgpt": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.19",

--- a/prompts/make-doc.md
+++ b/prompts/make-doc.md
@@ -4,6 +4,12 @@ I would like some help annotating some JSDoc documentation for some of my type u
 
 Here's an example of the code file for `$`, a very important type function that allows users to apply type functions to a type argument.
 
+# Few-shot Examples
+
+## Documentation for `$`
+
+### Code File for `$`
+
 ````ts
 import { Kind, Function } from "..";
 
@@ -160,14 +166,151 @@ export type $<
 >;
 ````
 
-With all that in mind, I would like some new documentation to be written for the following code file. This documentation should be an amazing level of quality.
+### Unit Tests for `$`
+
+```ts
+import { $, $$, Function, String, Test } from "hkt-toolbelt";
+
+type $_Spec = [
+  /**
+   * $ can apply kinds to types.
+   */
+  Test.Expect<$<Function.Identity, number>, number>,
+
+  /**
+   * $ enforces kind inputs.
+   */
+  // @ts-expect-error
+  $<String.StartsWith<"foo">, number>,
+
+  /**
+   * $ will emit an error on non-kinds.
+   */
+  // @ts-expect-error
+  $<number, number>
+];
+```
+
+## Documentation for `Boolean.And`
+
+### Code File for `Boolean.And`
+
+````ts
+import { Kind, Type } from "..";
+
+/**
+ * `_$and` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'and' logical operation
+ * on `T` and `U`. If both `T` and `U` are true, then `_$and` returns true,
+ * otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$and` to determine whether two boolean types are
+ * both true. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * ```ts
+ * import { _$and } from "hkt-toolbelt";
+ *
+ * type Result = _$and<true, false>; // false
+ * ```
+ */
+export type _$and<T extends boolean, U extends boolean> = [T, U] extends [
+  true,
+  true
+]
+  ? true
+  : false;
+
+interface And_T<T extends boolean> extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], boolean>): _$and<T, typeof x>;
+}
+
+/**
+ * `And` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'and' logical operation
+ * on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `And` to determine whether two boolean types are
+ * both true. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * We apply `And` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, And } from "hkt-toolbelt";
+ *
+ * type Result = $<$<And, true>, false>; // false
+ * ```
+ */
+export interface And extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], boolean>): And_T<typeof x>;
+}
+````
+
+### Unit Tests for `Boolean.And`
+
+```ts
+import { $, Boolean, Test } from "hkt-toolbelt";
+
+type And_Spec = [
+  /**
+   * True && True = True
+   */
+  Test.Expect<$<$<Boolean.And, true>, true>>,
+
+  /**
+   * True && False = False
+   */
+  Test.ExpectNot<$<$<Boolean.And, true>, false>>,
+
+  /**
+   * False && True = False
+   */
+  Test.ExpectNot<$<$<Boolean.And, false>, true>>,
+
+  /**
+   * False && False = False
+   */
+  Test.ExpectNot<$<$<Boolean.And, false>, false>>,
+
+  /**
+   * Running 'And' on a non-boolean type should emit an error.
+   */
+  // @ts-expect-error
+  Test.Expect<$<Boolean.And<true>, number>>
+];
+```
+
+# Prompt
+
+With all that in mind, I would like some new documentation to be written for
+the following input code file. This documentation should be written in a similar
+style to the above, but feel free to take liberties and express creativity.
 
 ```ts
 <FILE_CONTENTS>
 ```
 
-To provide context, here are the unit tests for the code file:
+To provide context, here are the unit tests for the input code file:
 
 ```ts
 <UNIT_TEST_CONTENTS>
 ```
+
+You only need to emit the code for the documented input code file. You do not
+need to emit the unit tests.

--- a/prompts/make-doc.md
+++ b/prompts/make-doc.md
@@ -1,0 +1,173 @@
+Imagine you are the world's leading expert on TypeScript and higher-order types. You have written a library that allows users to build very sophisticated type-level logic. You have written a lot of documentation, but you are not sure if it is clear enough. You want to make sure that your documentation is clear and concise, and that it is easy for users to understand how to use your library.
+
+I would like some help annotating some JSDoc documentation for some of my type utilities. To explain, the library is called `hkt-toolbelt` and allows users to build very sophisticated 'type functions' is an expressive way.
+
+Here's an example of the code file for `$`, a very important type function that allows users to apply type functions to a type argument.
+
+````ts
+import { Kind, Function } from "..";
+
+/**
+ * `$` is the most fundamental type in `hkt-toolbelt`. `$` is a generic type
+ * which takes in a type-level function and an input type, and returns the
+ * resultant output type of the type-level function, when applied to the input.
+ *
+ * This is a type-level equivalent of an 'apply' function.
+ *
+ * `$` operates via partial application. This means that `$` can be used to
+ * partially apply a type-level function, and then apply the partially applied
+ * type-level function to a different input type. All applications of `$` must
+ * be curried.
+ *
+ * ## Higher Order Type-Level Functions
+ *
+ * The reason that we use `$` instead of normal generic type parameters is that
+ * we want to be able to partially apply type-level functions. If we used
+ * normal generic type parameters, we would not be able to perform partial
+ * application, nor would we be able to take in or reference 'unapplied' types.
+ *
+ * As well, in base TypeScript, generics may not take in other generics. In
+ * other words, the following is not valid TypeScript:
+ *
+ * ```ts
+ * type Apply<F, X> = F<X>; // 'Type 'F' is not generic.'
+ * ```
+ *
+ * If we wanted to create a 'Map' type, we would not be able to do so with
+ * normal generic type parameters. Instead, we would need to use a higher-order
+ * type-level function. That is what `hkt-toolbelt` provides.
+ *
+ * ## Parameters
+ *
+ * @param F A type-level function.
+ * @param X The input type to apply the type-level function to.
+ *
+ * ## Examples
+ *
+ * ### Basic Usage
+ *
+ * @example
+ *
+ * For example, `Function.Identity` is a type-level function which takes in one
+ * argument: the input type. `Function.Identity` returns the input type that was
+ * passed in.
+ *
+ * Applying `Function.Identity` to a type will result in the type that was
+ * passed in:
+ *
+ * ```ts
+ * import { Kind, Function } from "hkt-toolbelt";
+ * type Result = $<Function.Identity, "foo">; // "foo"
+ * ```
+ *
+ * @example
+ *
+ * For example, `String.Append` is a type-level function which takes in two
+ * arguments: first, the string to append, and second, the string to append to.
+ *
+ * Only applying `String.Append` to one argument will result in a partially
+ * applied type-level function. This partially applied type-level function can
+ * then be applied to a different input type.
+ *
+ * ```ts
+ * import { Kind, String } from "hkt-toolbelt";
+ * type AppendBar = $<String.Append, "bar">;
+ * type Result = $<AppendBar, "foo">; // "foobar"
+ * ```
+ *
+ * Intermediary type aliases are not necessary, but they can be useful for
+ * readability. The following example is equivalent to the previous example.
+ *
+ * ```ts
+ * import { Kind, String } from "hkt-toolbelt";
+ * type Result = $<$<String.Append, "bar">, "foo">; // "foobar"
+ * ```
+ *
+ * ### Advanced Usage
+ *
+ * @example
+ *
+ * For example, `List.Map` is a type-level function which takes in two
+ * arguments: first, a type-level function, and second, a list. `List.Map`
+ * returns a list of the same length as the input list, where each element is
+ * the result of applying the type-level function to the corresponding element
+ * in the input list.
+ *
+ * This example applies `List.Map` to a partially applied `String.Append` type-
+ * level function, and a list of strings. The result is a list of strings, where
+ * each string has been appended with the string "bar".
+ *
+ * ```ts
+ * import { Kind, List, String } from "hkt-toolbelt";
+ * type Result = $<
+ *  $<List.Map, $<String.Append, "bar">,
+ *  ["foo", "baz"]
+ * >; // ["foobar", "bazbar"]
+ * ```
+ *
+ * This example is a nice demonstration of functionality that cannot easily be
+ * achieved with normal generic type parameters.
+ *
+ * @example
+ *
+ * For example, `List.Filter` is a type-level function which takes in two
+ * arguments: first, a type-level function, and second, a list. `List.Filter`
+ * will only return the elements of the input list where the type-level
+ * function returns the type `true`.
+ *
+ * This example applies `List.Filter` to a partially applied `String.Includes`,
+ * and a list of strings. The result is a list of strings, where each string
+ * includes the string "bar".
+ *
+ * Here we show where each intermediary step has been given a type alias. This
+ * is not necessary, but it can be useful for readability and reusability.
+ *
+ * ```ts
+ * import { Kind, List, String } from "hkt-toolbelt";
+ *
+ * // Does the string include "bar"?
+ * type IncludesBar = $<String.Includes, "bar">;
+ *
+ * // Filter the list for strings that include "bar".
+ * type FilterForBar = $<List.Filter, IncludesBar>;
+ *
+ * // Apply the filter to the list.
+ * type Result = $<
+ *   FilterForBar,
+ *   ["foo", "foobar", "baz", "barqux"]
+ * >; // ["foobar", "barqux"]
+ * ```
+ *
+ * In conclusion, `hkt-toolbelt` provides a powerful set of type-level
+ * functions, which can be used to create complex type-level logic. The `$`
+ * type is the most fundamental type in `hkt-toolbelt`, and is used to apply
+ * type-level functions to input types.
+ */
+export type $<
+  /**
+   * A higher-order type-level function.
+   */
+  F extends Kind.Kind,
+  /**
+   * The input type of the type-level function. `X` must be a subtype of the
+   * input type of the type-level function.
+   */
+  X extends Kind._$inputOf<F>
+> = Function._$returnType<
+  (F & {
+    readonly [Kind._]: X;
+  })["f"]
+>;
+````
+
+With all that in mind, I would like some new documentation to be written for the following code file. This documentation should be an amazing level of quality.
+
+```ts
+<FILE_CONTENTS>
+```
+
+To provide context, here are the unit tests for the code file:
+
+```ts
+<UNIT_TEST_CONTENTS>
+```

--- a/prompts/make-doc.md
+++ b/prompts/make-doc.md
@@ -312,4 +312,4 @@ To provide context, here are the unit tests for the input code file:
 <UNIT_TEST_CONTENTS>
 ```
 
-Please only output the JSDoc annotated code file, and not the unit tests.
+Please only output the JSDoc annotated code file, inside of a markdown code block.

--- a/prompts/make-doc.md
+++ b/prompts/make-doc.md
@@ -8,7 +8,7 @@ Here's an example of the code file for `$`, a very important type function that 
 
 ## Documentation for `$`
 
-### Code File for `$`
+### Code File for `src/$/$.ts`
 
 ````ts
 import { Kind, Function } from "..";
@@ -166,7 +166,7 @@ export type $<
 >;
 ````
 
-### Unit Tests for `$`
+### Unit Tests for `src/$/$.spec.ts`
 
 ```ts
 import { $, $$, Function, String, Test } from "hkt-toolbelt";
@@ -191,9 +191,7 @@ type $_Spec = [
 ];
 ```
 
-## Documentation for `Boolean.And`
-
-### Code File for `Boolean.And`
+## Documentation for `src/boolean/and.ts`
 
 ````ts
 import { Kind, Type } from "..";
@@ -218,9 +216,9 @@ import { Kind, Type } from "..";
  * to the type-level function:
  *
  * ```ts
- * import { _$and } from "hkt-toolbelt";
+ * import { Boolean } from "hkt-toolbelt";
  *
- * type Result = _$and<true, false>; // false
+ * type Result = Boolean._$and<true, false>; // false
  * ```
  */
 export type _$and<T extends boolean, U extends boolean> = [T, U] extends [
@@ -252,9 +250,9 @@ interface And_T<T extends boolean> extends Kind.Kind {
  * applicator:
  *
  * ```ts
- * import { $, And } from "hkt-toolbelt";
+ * import { $, Boolean } from "hkt-toolbelt";
  *
- * type Result = $<$<And, true>, false>; // false
+ * type Result = $<$<Boolean.And, true>, false>; // false
  * ```
  */
 export interface And extends Kind.Kind {
@@ -262,7 +260,7 @@ export interface And extends Kind.Kind {
 }
 ````
 
-### Unit Tests for `Boolean.And`
+### Unit Tests for `src/boolean/and.spec.ts`
 
 ```ts
 import { $, Boolean, Test } from "hkt-toolbelt";
@@ -302,6 +300,8 @@ With all that in mind, I would like some new documentation to be written for
 the following input code file. This documentation should be written in a similar
 style to the above, but feel free to take liberties and express creativity.
 
+## Documentation for `<FILE_PATH>`:
+
 ```ts
 <FILE_CONTENTS>
 ```
@@ -312,5 +312,4 @@ To provide context, here are the unit tests for the input code file:
 <UNIT_TEST_CONTENTS>
 ```
 
-You only need to emit the code for the documented input code file. You do not
-need to emit the unit tests.
+Please only output the JSDoc annotated code file, and not the unit tests.

--- a/src/$/$$.ts
+++ b/src/$/$$.ts
@@ -1,5 +1,89 @@
 import { Kind, List } from "..";
 
+/**
+ * `$$` is a type-level function in `hkt-toolbelt` that allows users to pipe
+ * multiple type-level functions together and apply them to an input.
+ *
+ * ## Purpose
+ *
+ * `hkt-toolbelt` provides a variety of higher-order type-level functions that
+ * enable users to create complex type-level logic. However, it can be
+ * challenging to apply multiple type-level functions to an input without
+ * resorting to using intermediary type aliases.
+ *
+ * For example, imagine we want to append a string to a list of strings and
+ * then join the resulting list. We would write this as the following, using
+ * `Kind.Pipe`.
+ *
+ * `Kind.Pipe` is a type-level function that takes a tuple of type-level
+ * functions and composes them from left to right.
+ *
+ * ```ts
+ * import { Kind, List, String } from "hkt-toolbelt";
+ *
+ * type Result = $<
+ *   $<Kind.Pipe,
+ *   [
+ *     $<List.Push, "foo">,
+ *     $<String.Join, " ">
+ *   ]>,
+ *   ["bar", "baz"]
+ * > // "bar baz foo"
+ * ```
+ *
+ * This is quite verbose. We can use `$$` to make this code more readable:
+ *
+ * ```ts
+ * import { Kind, List, String, $$ } from "hkt-toolbelt";
+ *
+ * type Result = $$<
+ *   [
+ *     $<List.Push, "foo">,
+ *     $<String.Join, " ">
+ *   ],
+ *   ["bar", "baz"]
+ * >; // "bar baz foo"
+ * ```
+ *
+ * Here, `$$` is being used to pipe `List.Push` and `String.Join` together and
+ * then apply them to a list of strings.
+ *
+ * ## Parameters
+ *
+ * @param FX A tuple of type-level functions that will be piped together.
+ * @param X The input type that the type-level functions will be applied to.
+ *
+ * ## Examples
+ *
+ * ### Basic Usage
+ *
+ * @example
+ *
+ * Here's a basic example that uses `$$` to apply a type-level function to an
+ * input type:
+ *
+ * ```ts
+ * import { Kind, List, $$ } from "hkt-toolbelt";
+ *
+ * type Result = $$<
+ *   [$<List.Push, "bar">, List.Unshift<"foo">],
+ *   [1, 2, 3]
+ * >; // ["foo", 1, 2, 3, "bar"]
+ * ```
+ *
+ * Here, `List.Push` and `List.Unshift` are being piped together using `$$` to
+ * append "bar" to a list of numbers and then prepend "foo".
+ *
+ * ## Errors
+ *
+ * `$$` will enforce that the Nth type-level function's output is a subtype of
+ * the (N + 1)th input. If this is not the case, `$$` will return the `never`
+ * type.
+ *
+ * If you receive a `never` type, it can be helpful to use the `Kind.InputOf`
+ * and `Kind.OutputOf` type-level functions to inspect the input and output
+ * types of the type-level functions that you are piping together.
+ */
 export type $$<
   FX extends Kind.Kind[],
   X extends FX extends [] ? unknown : Kind._$inputOf<List._$first<FX>>

--- a/src/$/$.ts
+++ b/src/$/$.ts
@@ -1,7 +1,151 @@
 import { Kind, Function } from "..";
 
+/**
+ * `$` is the most fundamental type in `hkt-toolbelt`. `$` is a generic type
+ * which takes in a type-level function and an input type, and returns the
+ * resultant output type of the type-level function, when applied to the input.
+ * 
+ * This is a type-level equivalent of an 'apply' function.
+ * 
+ * `$` operates via partial application. This means that `$` can be used to
+ * partially apply a type-level function, and then apply the partially applied
+ * type-level function to a different input type. All applications of `$` must
+ * be curried.
+ * 
+ * ## Higher Order Type-Level Functions
+ * 
+ * The reason that we use `$` instead of normal generic type parameters is that
+ * we want to be able to partially apply type-level functions. If we used
+ * normal generic type parameters, we would not be able to perform partial
+ * application, nor would we be able to take in or reference 'unapplied' types.
+ * 
+ * As well, in base TypeScript, generics may not take in other generics. In
+ * other words, the following is not valid TypeScript:
+ * 
+ * ```ts
+ * type Apply<F, X> = F<X>; // 'Type 'F' is not generic.'
+ * ```
+ * 
+ * If we wanted to create a 'Map' type, we would not be able to do so with
+ * normal generic type parameters. Instead, we would need to use a higher-order
+ * type-level function. That is what `hkt-toolbelt` provides.
+ * 
+ * ## Parameters
+ * 
+ * @param F A type-level function.
+ * @param X The input type to apply the type-level function to.
+ * 
+ * ## Examples
+ * 
+ * ### Basic Usage
+ * 
+ * @example
+ * 
+ * For example, `Function.Identity` is a type-level function which takes in one
+ * argument: the input type. `Function.Identity` returns the input type that was
+ * passed in.
+ * 
+ * Applying `Function.Identity` to a type will result in the type that was
+ * passed in:
+ * 
+ * ```ts
+ * import { Kind, Function } from "hkt-toolbelt";
+ * type Result = $<Function.Identity, "foo">; // "foo"
+ * ```
+ * 
+ * @example
+ * 
+ * For example, `String.Append` is a type-level function which takes in two
+ * arguments: first, the string to append, and second, the string to append to.
+ * 
+ * Only applying `String.Append` to one argument will result in a partially
+ * applied type-level function. This partially applied type-level function can
+ * then be applied to a different input type.
+ * 
+ * ```ts
+ * import { Kind, String } from "hkt-toolbelt";
+ * type AppendBar = $<String.Append, "bar">;
+ * type Result = $<AppendBar, "foo">; // "foobar"
+ * ```
+ * 
+ * Intermediary type aliases are not necessary, but they can be useful for
+ * readability. The following example is equivalent to the previous example.
+ * 
+ * ```ts
+ * import { Kind, String } from "hkt-toolbelt";
+ * type Result = $<$<String.Append, "bar">, "foo">; // "foobar"
+ * ```
+ * 
+ * ### Advanced Usage
+ * 
+ * @example
+ * 
+ * For example, `List.Map` is a type-level function which takes in two
+ * arguments: first, a type-level function, and second, a list. `List.Map`
+ * returns a list of the same length as the input list, where each element is
+ * the result of applying the type-level function to the corresponding element
+ * in the input list.
+ * 
+ * This example applies `List.Map` to a partially applied `String.Append` type-
+ * level function, and a list of strings. The result is a list of strings, where
+ * each string has been appended with the string "bar".
+ * 
+ * ```ts
+ * import { Kind, List, String } from "hkt-toolbelt";
+ * type Result = $<
+ *  $<List.Map, $<String.Append, "bar">,
+ *  ["foo", "baz"]
+ * >; // ["foobar", "bazbar"]
+ * ```
+ * 
+ * This example is a nice demonstration of functionality that cannot easily be
+ * achieved with normal generic type parameters.
+ * 
+ * @example
+ * 
+ * For example, `List.Filter` is a type-level function which takes in two
+ * arguments: first, a type-level function, and second, a list. `List.Filter`
+ * will only return the elements of the input list where the type-level
+ * function returns the type `true`.
+ * 
+ * This example applies `List.Filter` to a partially applied `String.Includes`,
+ * and a list of strings. The result is a list of strings, where each string
+ * includes the string "bar".
+ * 
+ * Here we show where each intermediary step has been given a type alias. This
+ * is not necessary, but it can be useful for readability and reusability.
+ * 
+ * ```ts
+ * import { Kind, List, String } from "hkt-toolbelt";
+ * 
+ * // Does the string include "bar"?
+ * type IncludesBar = $<String.Includes, "bar">;
+ * 
+ * // Filter the list for strings that include "bar".
+ * type FilterForBar = $<List.Filter, IncludesBar>;
+ * 
+ * // Apply the filter to the list.
+ * type Result = $<
+ *   FilterForBar,
+ *   ["foo", "foobar", "baz", "barqux"]
+ * >; // ["foobar", "barqux"]
+ * ```
+ * 
+ * In conclusion, `hkt-toolbelt` provides a powerful set of type-level
+ * functions, which can be used to create complex type-level logic. The `$`
+ * type is the most fundamental type in `hkt-toolbelt`, and is used to apply
+ * type-level functions to input types.
+ */
 export type $<
+  /**
+   * A higher-order type-level function.
+   */
   F extends Kind.Kind,
+
+  /**
+   * The input type of the type-level function. `X` must be a subtype of the
+   * input type of the type-level function.
+   */
   X extends Kind._$inputOf<F>
 > = Function._$returnType<
   (F & {

--- a/src/boolean/and.ts
+++ b/src/boolean/and.ts
@@ -20,9 +20,9 @@ import { Kind, Type } from "..";
  * to the type-level function:
  *
  * ```ts
- * import { _$and } from "hkt-toolbelt";
+ * import { Boolean } from "hkt-toolbelt";
  *
- * type Result = _$and<true, false>; // false
+ * type Result = Boolean._$and<true, false>; // false
  * ```
  */
 export type _$and<T extends boolean, U extends boolean> = [T, U] extends [
@@ -54,9 +54,9 @@ interface And_T<T extends boolean> extends Kind.Kind {
  * applicator:
  * 
  * ```ts
- * import { $, And } from "hkt-toolbelt";
+ * import { $, Boolean } from "hkt-toolbelt";
  * 
- * type Result = $<$<And, true>, false>; // false
+ * type Result = $<$<Boolean.And, true>, false>; // false
  * ```
  */
 export interface And extends Kind.Kind {

--- a/src/boolean/and.ts
+++ b/src/boolean/and.ts
@@ -1,5 +1,30 @@
 import { Kind, Type } from "..";
 
+/**
+ * `_$and` is a type-level function that takes in two boolean types, `T` and 
+ * `U`, and returns the boolean result of applying the 'and' logical operation 
+ * on `T` and `U`. If both `T` and `U` are true, then `_$and` returns true, 
+ * otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$and` to determine whether two boolean types are 
+ * both true. In this example, `true` and `false` are passed as type arguments 
+ * to the type-level function:
+ *
+ * ```ts
+ * import { _$and } from "hkt-toolbelt";
+ *
+ * type Result = _$and<true, false>; // false
+ * ```
+ */
 export type _$and<T extends boolean, U extends boolean> = [T, U] extends [
   true,
   true
@@ -11,6 +36,29 @@ interface And_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$and<T, typeof x>;
 }
 
+/**
+ * `And` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'and' logical operation
+ * on `T` and `U`.
+ * 
+ * @param T A boolean type.
+ * @param U A boolean type.
+ * 
+ * @example
+ * 
+ * For example, we can use `And` to determine whether two boolean types are
+ * both true. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ * 
+ * We apply `And` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ * 
+ * ```ts
+ * import { $, And } from "hkt-toolbelt";
+ * 
+ * type Result = $<$<And, true>, false>; // false
+ * ```
+ */
 export interface And extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): And_T<typeof x>;
 }

--- a/src/boolean/imply.ts
+++ b/src/boolean/imply.ts
@@ -1,9 +1,9 @@
 import { Kind, Type } from "..";
 
 /**
- * `_imply` is a type-level function that takes in two boolean types, `T` and
+ * `_$imply` is a type-level function that takes in two boolean types, `T` and
  * `U`, and returns the boolean result of applying the 'imply' logical
- * operation on `T` and `U`. If `T` is true and `U` is false, then `_imply`
+ * operation on `T` and `U`. If `T` is true and `U` is false, then `_$imply`
  * returns false, otherwise it returns true.
  *
  * This is also known as the 'logical implication' operator.
@@ -17,14 +17,14 @@ import { Kind, Type } from "..";
  *
  * @example
  *
- * For example, we can use `_imply` to determine whether a statement is true
+ * For example, we can use `_$imply` to determine whether a statement is true
  * given the truth values of two propositions, `T` and `U`. In this example,
  * `true` and `false` are passed as type arguments to the type-level function:
  *
  * ```ts
- * import { _imply } from "hkt-toolbelt";
+ * import { Boolean } from "hkt-toolbelt";
  *
- * type Result = _imply<true, false>; // false
+ * type Result = Boolean._$imply<true, false>; // false
  * ```
  */
 export type _$imply<T extends boolean, U extends boolean> = [T, U] extends [
@@ -58,9 +58,9 @@ interface Imply_T<T extends boolean> extends Kind.Kind {
  * applicator:
  *
  * ```ts
- * import { $, Imply } from "hkt-toolbelt";
+ * import { $, Boolean } from "hkt-toolbelt";
  *
- * type Result = $<$<Imply, true>, false>; // false
+ * type Result = $<$<Boolean.Imply, true>, false>; // false
  * ```
  */
 export interface Imply extends Kind.Kind {

--- a/src/boolean/imply.ts
+++ b/src/boolean/imply.ts
@@ -1,5 +1,32 @@
 import { Kind, Type } from "..";
 
+/**
+ * `_imply` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'imply' logical
+ * operation on `T` and `U`. If `T` is true and `U` is false, then `_imply`
+ * returns false, otherwise it returns true.
+ *
+ * This is also known as the 'logical implication' operator.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_imply` to determine whether a statement is true
+ * given the truth values of two propositions, `T` and `U`. In this example,
+ * `true` and `false` are passed as type arguments to the type-level function:
+ *
+ * ```ts
+ * import { _imply } from "hkt-toolbelt";
+ *
+ * type Result = _imply<true, false>; // false
+ * ```
+ */
 export type _$imply<T extends boolean, U extends boolean> = [T, U] extends [
   true,
   false
@@ -11,6 +38,31 @@ interface Imply_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$imply<T, typeof x>;
 }
 
+/**
+ * `Imply` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'imply' logical
+ * operation on `T` and `U`.
+ *
+ * This is also known as the 'logical implication' operator.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Imply` to determine whether a statement is true
+ * given the truth values of two propositions, `T` and `U`. In this example,
+ * `true` and `false` are passed as type arguments to the type-level function:
+ *
+ * We apply `Imply` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Imply } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Imply, true>, false>; // false
+ * ```
+ */
 export interface Imply extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Imply_T<typeof x>;
 }

--- a/src/boolean/nand.ts
+++ b/src/boolean/nand.ts
@@ -1,5 +1,30 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_nand` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'nand' logical operation
+ * on `T` and `U`. If both `T` and `U` are true, then `_nand` returns false,
+ * otherwise it returns true.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_nand` to determine whether two boolean types are
+ * not both true. In this example, `true` and `false` are passed as type
+ * arguments to the type-level function:
+ *
+ * ```ts
+ * import { _nand } from "hkt-toolbelt";
+ *
+ * type Result = _nand<true, false>; // true
+ * ```
+ */
 export type _$nand<T extends boolean, U extends boolean> = [T, U] extends [
   true,
   true
@@ -11,6 +36,29 @@ interface Nand_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$nand<T, typeof x>;
 }
 
+/**
+ * `Nand` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'nand' logical operation
+ * on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Nand` to determine whether two boolean types are
+ * not both true. In this example, `true` and `false` are passed as type
+ * arguments to the type-level function:
+ *
+ * We apply `Nand` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Nand } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Nand, true>, false>; // true
+ * ```
+ */
 export interface Nand extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Nand_T<typeof x>;
 }

--- a/src/boolean/nand.ts
+++ b/src/boolean/nand.ts
@@ -1,9 +1,9 @@
 import { Type, Kind } from "..";
 
 /**
- * `_nand` is a type-level function that takes in two boolean types, `T` and
+ * `_$nand` is a type-level function that takes in two boolean types, `T` and
  * `U`, and returns the boolean result of applying the 'nand' logical operation
- * on `T` and `U`. If both `T` and `U` are true, then `_nand` returns false,
+ * on `T` and `U`. If both `T` and `U` are true, then `_$nand` returns false,
  * otherwise it returns true.
  *
  * ## Parameters
@@ -15,14 +15,14 @@ import { Type, Kind } from "..";
  *
  * @example
  *
- * For example, we can use `_nand` to determine whether two boolean types are
+ * For example, we can use `_$nand` to determine whether two boolean types are
  * not both true. In this example, `true` and `false` are passed as type
  * arguments to the type-level function:
  *
  * ```ts
- * import { _nand } from "hkt-toolbelt";
+ * import { Boolean } from "hkt-toolbelt";
  *
- * type Result = _nand<true, false>; // true
+ * type Result = Boolean._$nand<true, false>; // true
  * ```
  */
 export type _$nand<T extends boolean, U extends boolean> = [T, U] extends [
@@ -54,9 +54,9 @@ interface Nand_T<T extends boolean> extends Kind.Kind {
  * applicator:
  *
  * ```ts
- * import { $, Nand } from "hkt-toolbelt";
+ * import { $, Boolean } from "hkt-toolbelt";
  *
- * type Result = $<$<Nand, true>, false>; // true
+ * type Result = $<$<Boolean.Nand, true>, false>; // true
  * ```
  */
 export interface Nand extends Kind.Kind {

--- a/src/boolean/nimply.ts
+++ b/src/boolean/nimply.ts
@@ -20,9 +20,9 @@ import { Kind, Type } from "..";
  * `false` are passed as type arguments to the type-level function:
  *
  * ```ts
- * import { _$nimply } from "hkt-toolbelt";
+ * import { Boolean } from "hkt-toolbelt";
  *
- * type Result = _$nimply<true, false>; // true
+ * type Result = Boolean._$nimply<true, false>; // true
  * ```
  */
 export type _$nimply<T extends boolean, U extends boolean> = [T, U] extends [
@@ -54,9 +54,9 @@ interface Nimply_T<T extends boolean> extends Kind.Kind {
  * applicator:
  *
  * ```ts
- * import { $, Nimply } from "hkt-toolbelt";
+ * import { $, Boolean } from "hkt-toolbelt";
  *
- * type Result = $<$<Nimply, true>, false>; // true
+ * type Result = $<$<Boolean.Nimply, true>, false>; // true
  * ```
  */
 export interface Nimply extends Kind.Kind {

--- a/src/boolean/nimply.ts
+++ b/src/boolean/nimply.ts
@@ -1,5 +1,30 @@
 import { Kind, Type } from "..";
 
+/**
+ * `_$nimply` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'not-implies' logical
+ * operation on `T` and `U`. If `T` is true and `U` is false, then `_$nimply`
+ * returns true, otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$nimply` to determine whether two boolean types
+ * follow the 'not-implies' logical operation. In this example, `true` and
+ * `false` are passed as type arguments to the type-level function:
+ *
+ * ```ts
+ * import { _$nimply } from "hkt-toolbelt";
+ *
+ * type Result = _$nimply<true, false>; // true
+ * ```
+ */
 export type _$nimply<T extends boolean, U extends boolean> = [T, U] extends [
   true,
   false
@@ -11,6 +36,29 @@ interface Nimply_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$nimply<T, typeof x>;
 }
 
+/**
+ * `Nimply` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'not-implies' logical
+ * operation on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Nimply` to determine whether two boolean types
+ * follow the 'not-implies' logical operation. In this example, `true` and
+ * `false` are passed as type arguments to the type-level function:
+ *
+ * We apply `Nimply` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Nimply } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Nimply, true>, false>; // true
+ * ```
+ */
 export interface Nimply extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Nimply_T<typeof x>;
 }

--- a/src/boolean/nor.ts
+++ b/src/boolean/nor.ts
@@ -1,5 +1,30 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_$nor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'nor' logical operation
+ * on `T` and `U`. If both `T` and `U` are false, then `_$nor` returns true,
+ * otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$nor` to determine whether two boolean types are
+ * both false. In this example, `true` and `true` are passed as type arguments
+ * to the type-level function:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$nor<true, true>; // false
+ * ```
+ */
 export type _$nor<T extends boolean, U extends boolean> = [T, U] extends [
   false,
   false
@@ -11,6 +36,29 @@ interface Nor_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$nor<T, typeof x>;
 }
 
+/**
+ * `Nor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'nor' logical operation
+ * on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Nor` to determine whether two boolean types are both
+ * false. In this example, `true` and `true` are passed as type arguments to the
+ * type-level function:
+ *
+ * We apply `Nor` to `true` and `true` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Boolean.Nor, true>, true>; // false
+ * ```
+ */
 export interface Nor extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Nor_T<typeof x>;
 }

--- a/src/boolean/not.ts
+++ b/src/boolean/not.ts
@@ -1,7 +1,46 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_$not` is a type-level function that takes in a boolean type `T`, and
+ * returns the boolean result of applying the 'not' logical operation on `T`.
+ * If `T` is true, then `_$not` returns false, otherwise it returns true.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$not` to negate a boolean type:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$not<true>; // false
+ * ```
+ */
 export type _$not<T extends boolean> = T extends true ? false : true;
 
+/**
+ * `Not` is a type-level function that takes in a boolean type `T`, and
+ * returns the boolean result of applying the 'not' logical operation on `T`.
+ *
+ * @param T A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Not` to negate a boolean type:
+ *
+ * We apply `Not` to `true` using the `$` type-level applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<Boolean.Not, true>; // false
+ * ```
+ */
 export interface Not extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$not<typeof x>;
 }

--- a/src/boolean/or.ts
+++ b/src/boolean/or.ts
@@ -1,5 +1,30 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_$or` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'or' logical operation
+ * on `T` and `U`. If either `T` or `U` is true, then `_$or` returns true,
+ * otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$or` to determine whether at least one of two boolean
+ * types is true. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$or<true, false>; // true
+ * ```
+ */
 export type _$or<T extends boolean, U extends boolean> = [T, U] extends [
   false,
   false
@@ -11,6 +36,29 @@ interface Or_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$or<T, typeof x>;
 }
 
+/**
+ * `Or` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'or' logical operation
+ * on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Or` to determine whether at least one of two boolean
+ * types is true. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * We apply `Or` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Boolean.Or, true>, false>; // true
+ * ```
+ */
 export interface Or extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Or_T<typeof x>;
 }

--- a/src/boolean/xnor.ts
+++ b/src/boolean/xnor.ts
@@ -1,5 +1,41 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_$xnor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'xnor' logical operation
+ * on `T` and `U`. If `T` and `U` are equal, then `_$xnor` returns true,
+ * otherwise it returns false.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Examples
+ *
+ * @example
+ *
+ * For example, we can use `_$xnor` to determine whether two boolean types are
+ * equal. In this example, `true` and `true` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$xnor<true, true>; // true
+ * ```
+ *
+ * @example
+ *
+ * In this example, `true` and `false` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$xnor<true, false>; // false
+ * ```
+ */
 export type _$xnor<T extends boolean, U extends boolean> = T extends U
   ? true
   : false;
@@ -8,6 +44,47 @@ interface Xnor_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$xnor<T, typeof x>;
 }
 
+/**
+ * `Xnor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'xnor' logical operation
+ * on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Xnor` to determine whether two boolean types are
+ * equal. In this example, `true` and `true` are passed as type arguments to the
+ * type-level function:
+ *
+ * We apply `Xnor` to `true` and `true` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Boolean.Xnor, true>, true>; // true
+ * ```
+ *
+ * @example
+ *
+ * In this example, `true` and `false` are passed as type arguments to the
+ * type-level function:
+ *
+ * We apply `Xnor` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Boolean.Xnor, true>, false>; // false
+ * ```
+ *
+ * The 'xnor' operation is a logical operation which stands for 'exclusive nor'.
+ * The xnor operation returns true if and only if its operands are equal. It is
+ * equivalent to the negation of the xor (exclusive or) operation.
+ */
 export interface Xnor extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Xnor_T<typeof x>;
 }

--- a/src/boolean/xor.ts
+++ b/src/boolean/xor.ts
@@ -1,5 +1,30 @@
 import { Type, Kind } from "..";
 
+/**
+ * `_$xor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'exclusive or' (xor)
+ * logical operation on `T` and `U`. If `T` and `U` are the same, then
+ * `_$xor` returns false, otherwise it returns true.
+ *
+ * ## Parameters
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$xor` to determine whether two boolean types are
+ * different. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * ```ts
+ * import { Boolean } from "hkt-toolbelt";
+ *
+ * type Result = Boolean._$xor<true, false>; // true
+ * ```
+ */
 export type _$xor<T extends boolean, U extends boolean> = T extends U
   ? false
   : true;
@@ -8,6 +33,47 @@ interface Xor_T<T extends boolean> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): _$xor<T, typeof x>;
 }
 
+/**
+ * `Xor` is a type-level function that takes in two boolean types, `T` and
+ * `U`, and returns the boolean result of applying the 'exclusive or' (xor)
+ * logical operation on `T` and `U`.
+ *
+ * @param T A boolean type.
+ * @param U A boolean type.
+ *
+ * @example
+ *
+ * For example, we can use `Xor` to determine whether two boolean types are
+ * different. In this example, `true` and `false` are passed as type arguments
+ * to the type-level function:
+ *
+ * We apply `Xor` to `true` and `false` respectively using the `$` type-level
+ * applicator:
+ *
+ * ```ts
+ * import { $, Boolean } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Boolean.Xor, true>, false>; // true
+ * ```
+ *
+ * ### Exclusive Or (XOR) Operation
+ *
+ * The 'exclusive or' operation (XOR) is a logical operation that outputs true
+ * only when the inputs differ. In other words, it returns false when the
+ * inputs are the same.
+ *
+ * Here's a truth table for the XOR operation:
+ *
+ * | Input A | Input B | Output |
+ * | ------- | ------- | ------ |
+ * | true    | true    | false  |
+ * | true    | false   | true   |
+ * | false   | true    | true   |
+ * | false   | false   | false  |
+ *
+ * The XOR operation can also be thought of as the negation of the equality
+ * operation (i.e., `A !== B` is equivalent to `A ^ B`).
+ */
 export interface Xor extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], boolean>): Xor_T<typeof x>;
 }

--- a/src/kind/composable-pair.spec.ts
+++ b/src/kind/composable-pair.spec.ts
@@ -1,0 +1,21 @@
+import { $, String, Test, Kind, List } from "..";
+
+type ComposablePair_Spec = [
+  /**
+   * Simple list operations should be composable.
+   */
+  Test.Expect<
+    Kind._$composablePair<[$<List.Push, "foo">, List.Unshift<"bar">]>
+  >,
+
+  /**
+   * A list push (on strings) and a string.join should be composable.
+   */
+  Test.Expect<Kind._$composablePair<[$<String.Join, "">, $<List.Push, "foo">]>>,
+
+  /**
+   * The empty tuple should emit an error.
+   */
+  // @ts-expect-error
+  Kind._$composablePair<[]>
+];

--- a/src/kind/composable-pair.ts
+++ b/src/kind/composable-pair.ts
@@ -1,10 +1,7 @@
 import { Type, Kind } from "..";
 
-type _$composablePair<F extends [Kind.Kind, Kind.Kind]> = Kind._$outputOf<
-  F[1]
-> extends Kind._$inputOf<F[0]>
-  ? true
-  : false;
+export type _$composablePair<F extends [Kind.Kind, Kind.Kind]> =
+  Kind._$outputOf<F[1]> extends Kind._$inputOf<F[0]> ? true : false;
 
 export interface ComposablePair extends Kind.Kind {
   f(

--- a/src/string/join.ts
+++ b/src/string/join.ts
@@ -1,7 +1,7 @@
 import { Type, Kind, List } from "..";
 
 export type _$join<
-  T extends string[],
+  T extends (string | unknown)[],
   D extends string = "",
   O extends string = ""
 > = List._$isVariadic<T> extends true
@@ -19,7 +19,7 @@ export type _$join<
   : O;
 
 interface Join_T<D extends string> extends Kind.Kind {
-  f(x: Type._$cast<this[Kind._], string[]>): _$join<typeof x, D>;
+  f(x: Type._$cast<this[Kind._], (string | unknown)[]>): _$join<typeof x, D>;
 }
 
 export interface Join extends Kind.Kind {


### PR DESCRIPTION
This pull request introduces a few-shot LLM meta-prompt pipeline for writing JSDoc, as well as high-quality comments for the `Boolean` module.

As a minor additional note, this pull request fixes a compatibility issue in `String.Join` with the pipeline composition operator. Amusingly, the type system accurately doesn't know for sure that the return type of a `List.Append` will necessarily be a list of strings only.

Since representing this 3rd order kind seems difficult and not very useful, I'm widening the type to `(string | unknown)[]`. Other types are likely to be widened in the future as we expand test cases for evaluation of higher-order type composition.