### PR TITLE
Add Conditional utilities `EqualsAll`, `ExtendsAll`

### DIFF
--- a/src/conditional/equals-all.spec.ts
+++ b/src/conditional/equals-all.spec.ts
@@ -1,6 +1,6 @@
 import { $, Conditional, Test, List, NaturalNumber } from "hkt-toolbelt"
 
-type Equals_Spec = [
+type EqualsAll_Spec = [
   /**
    * An empty array or an array of one element always returns true.
    */
@@ -11,7 +11,7 @@ type Equals_Spec = [
   /**
    * A non-array is not a valid argument.
    */
-  //@ts-expect-error
+  // @ts-expect-error
   Test.Expect<$<Conditional.EqualsAll, true>, true>,
 
   /**

--- a/src/conditional/equals-all.spec.ts
+++ b/src/conditional/equals-all.spec.ts
@@ -1,0 +1,75 @@
+import { $, Conditional, Test, List, NaturalNumber } from "hkt-toolbelt"
+
+type Equals_Spec = [
+  /**
+   * An empty array or an array of one element always returns true.
+   */
+  Test.Expect<$<Conditional.EqualsAll, []>, true>,
+  Test.Expect<$<Conditional.EqualsAll, [true]>, true>,
+  Test.Expect<$<Conditional.EqualsAll, [false]>, true>,
+
+  /**
+   * A non-array is not a valid argument.
+   */
+  //@ts-expect-error
+  Test.Expect<$<Conditional.EqualsAll, true>, true>,
+
+  /**
+   * An array whose elements are all identical always returns true.
+   */
+  Test.Expect<$<Conditional.EqualsAll, [never, never]>, true>,
+  Test.Expect<$<Conditional.EqualsAll, [unknown, unknown]>, true>,
+  Test.Expect<$<Conditional.EqualsAll, [true, true, true]>, true>,
+  Test.Expect<$<Conditional.EqualsAll, [false, false, false]>, true>,
+  Test.Expect<
+    $<Conditional.EqualsAll, [number, number, number, number, number, number]>,
+    true
+  >,
+  Test.Expect<
+    $<
+      Conditional.EqualsAll,
+      [boolean, boolean, boolean, boolean, boolean, boolean]
+    >,
+    true
+  >,
+
+  /**
+   * An array whose elements are all identical except for one element always returns false.
+   */
+  Test.Expect<$<Conditional.EqualsAll, [true, false]>, false>,
+  Test.Expect<$<Conditional.EqualsAll, [unknown, never]>, false>,
+  Test.Expect<
+    $<Conditional.EqualsAll, [true, false, true, true, true, true, true]>,
+    false
+  >,
+
+  /**
+   * Can correctly evaluate the identity of complex type expressions.
+   */
+  Test.Expect<
+    $<
+      Conditional.EqualsAll,
+      [PropertyKey, string | number | symbol, keyof any]
+    >,
+    true
+  >,
+  Test.Expect<
+    $<Conditional.EqualsAll, [string | number, number | string]>,
+    true
+  >,
+  Test.Expect<
+    $<Conditional.EqualsAll, [string, string & { length: 3 }]>,
+    false
+  >,
+  Test.Expect<
+    $<
+      Conditional.EqualsAll,
+      [
+        $<$<$<List.Reduce, NaturalNumber.Add>, 0>, [1, 2, 3, 4, 5]>,
+        $<$<NaturalNumber.Subtract, 20>, 5>,
+        15
+      ]
+    >,
+    true
+  >
+]

--- a/src/conditional/equals-all.ts
+++ b/src/conditional/equals-all.ts
@@ -2,7 +2,7 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
 
 /**
  * `_$equalsAll` is a type-level function that takes in an array of types `T`,
- * and returns `true` if all elements of `T` are equal.
+ * and returns `true` if all elements of `T` are equal or `T` is empty.
  *
  * ## Parameters
  *
@@ -66,7 +66,7 @@ export type _$equalsAll<
 
 /**
  * `EqualsAll` is a type-level function that takes in one array of types, `T`, and returns a
- * type-level function that returns `true` if all elements of `T` evaluate to the same type,
+ * type-level function that returns `true` if all elements of `T` evaluate to the same type or `T` is empty,
  * and `false` if otherwise.
  *
  * @param T An array of types.

--- a/src/conditional/equals-all.ts
+++ b/src/conditional/equals-all.ts
@@ -2,9 +2,7 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
 
 /**
  * `_$equalsAll` is a type-level function that takes in an array of types `T`,
- * and returns `true` if all elements of `T` are equal to its first element.
- * Optionally, a second type `U` can be supplied, in which case `true` will be returned
- * if and only if all elements of `T` are equal to `U`.
+ * and returns `true` if all elements of `T` are equal.
  *
  * ## Parameters
  *
@@ -59,16 +57,16 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  */
 export type _$equalsAll<
   T extends List.List,
-  U extends unknown = T[0],
-  APPLY = $<$<List.Map, $<Conditional.Equals, U>>, T>,
-  RESULT extends boolean = APPLY extends boolean[]
-    ? $<$<$<List.Reduce, Boolean.And>, true>, APPLY>
-    : never
-> = RESULT
+  PREV = T[0],
+> = T extends [infer CURR, ...infer REST]
+  ? Conditional._$equals<PREV, CURR> extends false
+    ? false
+    : _$equalsAll<REST, CURR>
+  : true
 
 /**
  * `EqualsAll` is a type-level function that takes in one array of types, `T`, and returns a
- * type-level function that returns `true` if all elements of `T` evaluate to the same type as the first element of `T`,
+ * type-level function that returns `true` if all elements of `T` evaluate to the same type,
  * and `false` if otherwise.
  *
  * @param T An array of types.

--- a/src/conditional/equals-all.ts
+++ b/src/conditional/equals-all.ts
@@ -1,0 +1,92 @@
+import { $, Type, Kind, List, Conditional, Boolean } from ".."
+
+/**
+ * `_$equalsAll` is a type-level function that takes in an array of types `T`,
+ * and returns `true` if all elements of `T` are equal to its first element.
+ * Optionally, a second type `U` can be supplied, in which case `true` will be returned
+ * if and only if all elements of `T` are equal to `U`.
+ *
+ * ## Parameters
+ *
+ * @param T An array of types.
+ * @param U A type.
+ *
+ * ## Examples
+ *
+ * @example
+ *
+ * For example, we can use `_$equalsAll` to determine whether a series of types are equal.
+ * In this example, `[false, false, false]` is passed as a type argument to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$equalsAll<[
+ *  false,
+ *  false,
+ *  false,
+ * ]>; // true
+ *
+ * @example
+ *
+ * For example, we can use `_$equalsAll` to determine whether a series of type expressions are all equal to a second input type.
+ * In this example, `[true, true]` and `unknown` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$equalsAll<[
+ *  true,
+ *  true,
+ * ], unknown>; // false
+ * ```
+ *
+ * @example
+ *
+ * In this example, `[string | number | symbol, keyof any]` and `PropertyKey` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$equalsAll<[
+ *  string | number | symbol,
+ *  keyof any,
+ * ], PropertyKey>; // true
+ * ```
+ */
+export type _$equalsAll<
+  T extends List.List,
+  U extends unknown = T[0],
+  APPLY = $<$<List.Map, $<Conditional.Equals, U>>, T>,
+  RESULT extends boolean = APPLY extends boolean[]
+    ? $<$<$<List.Reduce, Boolean.And>, true>, APPLY>
+    : never
+> = RESULT
+
+/**
+ * `EqualsAll` is a type-level function that takes in one array of types, `T`, and returns a
+ * type-level function that returns `true` if all elements of `T` evaluate to the same type as the first element of `T`,
+ * and `false` if otherwise.
+ *
+ * @param T An array of types.
+ *
+ * @example
+ *
+ * For example, we can use `EqualsAll` to determine whether multiple types are equal.
+ * In this example, `EqualsAll` is a type-level function that returns `true` if all elements of its input evaluate as being equal.
+ *
+ * We apply this type-level function to `[false, false, false]` and `[true, false]` respectively using the `$` type-level applicator:
+ *
+ * ```ts
+ * import { $, Conditional } from "hkt-toolbelt";
+ *
+ * type IsTrue = $<Conditional.EqualsAll, [false, false, false]>; // true
+ * type IsNotTrue = $<Conditional.EqualsAll, [true, false]>; // false
+ * ```
+ */
+export interface EqualsAll extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], List.List>): _$equalsAll<typeof x>
+}

--- a/src/conditional/extends-all.spec.ts
+++ b/src/conditional/extends-all.spec.ts
@@ -19,10 +19,10 @@ class Cat extends Animal {
 
 type ExtendsAll_Spec = [
   /**
-   * An empty array returns never.
+   * An empty array returns true.
    */
-  Test.Expect<$<$<Conditional.ExtendsAll, any>, []>, never>,
-  Test.Expect<$<$<Conditional.ExtendsAll, never>, []>, never>,
+  Test.Expect<$<$<Conditional.ExtendsAll, any>, []>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, never>, []>, true>,
 
   /**
    * A non-array is not a valid argument.

--- a/src/conditional/extends-all.spec.ts
+++ b/src/conditional/extends-all.spec.ts
@@ -17,12 +17,12 @@ class Cat extends Animal {
   }
 }
 
-type Equals_Spec = [
+type ExtendsAll_Spec = [
   /**
-   * An empty array always returns true.
+   * An empty array returns never.
    */
-  Test.Expect<$<$<Conditional.ExtendsAll, []>, any>, true>,
-  Test.Expect<$<$<Conditional.ExtendsAll, []>, never>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, any>, []>, never>,
+  Test.Expect<$<$<Conditional.ExtendsAll, never>, []>, never>,
 
   /**
    * A non-array is not a valid argument.
@@ -31,31 +31,31 @@ type Equals_Spec = [
   Test.Expect<$<$<Conditional.ExtendsAll, true>, true>, true>,
 
   /** Subclasses extend their Superclass */
-  Test.Expect<$<$<Conditional.ExtendsAll, [Cat, Dog]>, Animal>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, Animal>, [Cat, Dog]>, true>,
 
   /**
    * Instances extend their Types
    */
-  Test.Expect<$<$<Conditional.ExtendsAll, [true, false]>, boolean>, true>,
-  Test.Expect<$<$<Conditional.ExtendsAll, [0, 100, -100]>, number>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, boolean>, [true, false]>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, number>, [0, 100, -100]>, true>,
 
   /**
    * Subtypes extend Supertypes
    */
-  Test.Expect<$<$<Conditional.ExtendsAll, [never]>, unknown>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, unknown>, [never]>, true>,
 
   /**
    * Elements of Union Types extend their Unions.
    */
   Test.Expect<
     $<
-      $<Conditional.ExtendsAll, [string, number, boolean]>,
-      string | number | boolean
+      $<Conditional.ExtendsAll, string | number | boolean>,
+      [string, number, boolean]
     >,
     true
   >,
   Test.Expect<
-    $<$<Conditional.ExtendsAll, [string | number, string | boolean]>, string>,
+    $<$<Conditional.ExtendsAll, string>, [string | number, string | boolean]>,
     false
   >,
 
@@ -64,13 +64,13 @@ type Equals_Spec = [
    */
   Test.Expect<
     $<
-      $<Conditional.ExtendsAll, [{ a: 1 } & { b: 2 }, { a: 1 } & { c: 3 }]>,
-      { a: 1 }
+      $<Conditional.ExtendsAll, { a: 1 }>,
+      [{ a: 1 } & { b: 2 }, { a: 1 } & { c: 3 }]
     >,
     true
   >,
   Test.Expect<
-    $<$<Conditional.ExtendsAll, [{ a: 1 }, { b: 2 }]>, { a: 1 } & { b: 2 }>,
+    $<$<Conditional.ExtendsAll, { a: 1 } & { b: 2 }>, [{ a: 1 }, { b: 2 }]>,
     false
   >,
 
@@ -79,8 +79,8 @@ type Equals_Spec = [
    */
   Test.Expect<
     $<
-      $<Conditional.ExtendsAll, [any, unknown, never, string, number, boolean]>,
-      never
+      $<Conditional.ExtendsAll, never>,
+      [any, unknown, never, string, number, boolean]
     >,
     false
   >,
@@ -89,7 +89,7 @@ type Equals_Spec = [
    * `never` extends everything
    */
   Test.Expect<
-    $<$<Conditional.ExtendsAll, [never, never, never]>, any | unknown | never>,
+    $<$<Conditional.ExtendsAll, any | unknown | never>, [never, never, never]>,
     true
   >,
 
@@ -98,8 +98,8 @@ type Equals_Spec = [
    */
   Test.Expect<
     $<
-      $<Conditional.ExtendsAll, [any, unknown, never, string, number, boolean]>,
-      unknown
+      $<Conditional.ExtendsAll, unknown>,
+      [any, unknown, never, string, number, boolean]
     >,
     true
   >,
@@ -109,8 +109,8 @@ type Equals_Spec = [
    */
   Test.Expect<
     $<
-      $<Conditional.ExtendsAll, [unknown, unknown, unknown]>,
-      object | string | boolean | number | never
+      $<Conditional.ExtendsAll, object | string | boolean | number | never>,
+      [unknown, unknown, unknown]
     >,
     false
   >

--- a/src/conditional/extends-all.spec.ts
+++ b/src/conditional/extends-all.spec.ts
@@ -1,0 +1,117 @@
+import { $, Conditional, Test } from "hkt-toolbelt"
+
+class Animal {
+  name: string
+  constructor(name: string) {
+    this.name = name
+  }
+}
+class Dog extends Animal {
+  constructor(name: string) {
+    super(name)
+  }
+}
+class Cat extends Animal {
+  constructor(name: string) {
+    super(name)
+  }
+}
+
+type Equals_Spec = [
+  /**
+   * An empty array always returns true.
+   */
+  Test.Expect<$<$<Conditional.ExtendsAll, []>, any>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, []>, never>, true>,
+
+  /**
+   * A non-array is not a valid argument.
+   */
+  //@ts-expect-error
+  Test.Expect<$<$<Conditional.ExtendsAll, true>, true>, true>,
+
+  /** Subclasses extend their Superclass */
+  Test.Expect<$<$<Conditional.ExtendsAll, [Cat, Dog]>, Animal>, true>,
+
+  /**
+   * Instances extend their Types
+   */
+  Test.Expect<$<$<Conditional.ExtendsAll, [true, false]>, boolean>, true>,
+  Test.Expect<$<$<Conditional.ExtendsAll, [0, 100, -100]>, number>, true>,
+
+  /**
+   * Subtypes extend Supertypes
+   */
+  Test.Expect<$<$<Conditional.ExtendsAll, [never]>, unknown>, true>,
+
+  /**
+   * Elements of Union Types extend their Unions.
+   */
+  Test.Expect<
+    $<
+      $<Conditional.ExtendsAll, [string, number, boolean]>,
+      string | number | boolean
+    >,
+    true
+  >,
+  Test.Expect<
+    $<$<Conditional.ExtendsAll, [string | number, string | boolean]>, string>,
+    false
+  >,
+
+  /**
+   * Intersections extend their elements
+   */
+  Test.Expect<
+    $<
+      $<Conditional.ExtendsAll, [{ a: 1 } & { b: 2 }, { a: 1 } & { c: 3 }]>,
+      { a: 1 }
+    >,
+    true
+  >,
+  Test.Expect<
+    $<$<Conditional.ExtendsAll, [{ a: 1 }, { b: 2 }]>, { a: 1 } & { b: 2 }>,
+    false
+  >,
+
+  /**
+   * Nothing extends `never`
+   */
+  Test.Expect<
+    $<
+      $<Conditional.ExtendsAll, [any, unknown, never, string, number, boolean]>,
+      never
+    >,
+    false
+  >,
+
+  /**
+   * `never` extends everything
+   */
+  Test.Expect<
+    $<$<Conditional.ExtendsAll, [never, never, never]>, any | unknown | never>,
+    true
+  >,
+
+  /**
+   * Everything extends `unknown`
+   */
+  Test.Expect<
+    $<
+      $<Conditional.ExtendsAll, [any, unknown, never, string, number, boolean]>,
+      unknown
+    >,
+    true
+  >,
+
+  /**
+   * `unknown` extends nothing (except `any` and `unknown`)
+   */
+  Test.Expect<
+    $<
+      $<Conditional.ExtendsAll, [unknown, unknown, unknown]>,
+      object | string | boolean | number | never
+    >,
+    false
+  >
+]

--- a/src/conditional/extends-all.ts
+++ b/src/conditional/extends-all.ts
@@ -58,40 +58,39 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
 export type _$extendsAll<
   T extends List.List,
   U extends unknown,
-  APPLY = $<$<List.Map, $<Conditional.Extends, U>>, T>,
-  RESULT extends boolean = APPLY extends boolean[]
-    ? $<$<$<List.Reduce, Boolean.And>, true>, APPLY>
-    : never
-> = RESULT
+> = T extends [infer CURR, ...infer REST]
+  ? Conditional._$extends<U, CURR> extends false
+    ? false
+    : _$extendsAll<REST, U>
+  : never
 
-interface ExtendsAll_T<T extends List.List> extends Kind.Kind {
-  f(x: Type._$cast<this[Kind._], unknown>): _$extendsAll<T, typeof x>
+interface ExtendsAll_T<U extends unknown> extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], List.List>): _$extendsAll<typeof x, U>
 }
 
 /**
- * `ExtendsAll` is a type-level function that takes in an array of types, `T`, and a type `U`
- * and return sa type-level function that returns `true` if all elements of `T` extend `U`,
+ * `ExtendsAll` is a type-level function that takes in a type `U` and an array of types, `T`,
+ * and returns a type-level function that returns `true` if all elements of `T` extend `U`,
  * and `false` if otherwise.
  *
- * @param T An array of types.
  * @param U A type.
+ * @param T An array of types.
  *
  * @example
  *
  * For example, we can use `ExtendsAll` to determine whether a series of types all extend a second input type.
- * In this example, we partially apply `ExtendsAll` to `[string, number]`, which results in a
- * type-level function that returns `true` if `string` and `number` both extend its input.
+ * In this example, we partially apply `ExtendsAll` to `string | number` and `never`, which result in
+ * two type-level functions that return `true` if all elements of their input extend `string | number` and `never`, respectively.
  *
- * We then apply this partially applied function to `string | number` and `never`
- * respectively using the `$` type-level applicator:
+ * We then apply both of these partially applied functions to `[string, number]` using the `$` type-level applicator.
  *
  * ```ts
  * import { $, Conditional } from "hkt-toolbelt";
  *
- * type IsTrue = $<$<Conditional.ExtendsAll, [string, number]>, string | number>; // true
- * type IsNotTrue = $<$<Conditional.ExtendsAll, [string, number]>, never>; // false
+ * type IsTrue = $<$<Conditional.ExtendsAll, string | number>, [string, number]>; // true
+ * type IsNotTrue = $<$<Conditional.ExtendsAll, never>, [string, number]>; // false
  * ```
  */
 export interface ExtendsAll extends Kind.Kind {
-  f(x: Type._$cast<this[Kind._], List.List>): ExtendsAll_T<typeof x>
+  f(x: Type._$cast<this[Kind._], unknown>): ExtendsAll_T<typeof x>
 }

--- a/src/conditional/extends-all.ts
+++ b/src/conditional/extends-all.ts
@@ -2,7 +2,7 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
 
 /**
  * `_$extendsAll` is a type-level function that takes in an array of types `T` and a type `U`,
- * and returns `true` if and only if all elements of `T` extend `U`.
+ * and returns `true` if and only if all elements of `T` extend `U`, or `T` is empty.
  * Otherwise it returns `false`.
  *
  * ## Parameters
@@ -62,7 +62,7 @@ export type _$extendsAll<
   ? Conditional._$extends<U, CURR> extends false
     ? false
     : _$extendsAll<REST, U>
-  : never
+  : true
 
 interface ExtendsAll_T<U extends unknown> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], List.List>): _$extendsAll<typeof x, U>
@@ -72,6 +72,8 @@ interface ExtendsAll_T<U extends unknown> extends Kind.Kind {
  * `ExtendsAll` is a type-level function that takes in a type `U` and an array of types, `T`,
  * and returns a type-level function that returns `true` if all elements of `T` extend `U`,
  * and `false` if otherwise.
+ * 
+ * If T is empty, `true` is returned.
  *
  * @param U A type.
  * @param T An array of types.

--- a/src/conditional/extends-all.ts
+++ b/src/conditional/extends-all.ts
@@ -1,0 +1,97 @@
+import { $, Type, Kind, List, Conditional, Boolean } from ".."
+
+/**
+ * `_$extendsAll` is a type-level function that takes in an array of types `T` and a type `U`,
+ * and returns `true` if and only if all elements of `T` extend `U`.
+ * Otherwise it returns `false`.
+ *
+ * ## Parameters
+ *
+ * @param T An array of types.
+ * @param U A type.
+ *
+ * ## Examples
+ *
+ * @example
+ *
+ * For example, we can use `_$extendsAll` to determine whether a series of type expressions all extend a second input type.
+ * In this example, `[true, false]` and `boolean` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$extendsAll<[
+ *  true,
+ *  false,
+ * ], boolean>; // true
+ * ```
+ *
+ * @example
+ *
+ * For example, we can use `_$extendsAll` to determine whether a series of types all extend the second input type.
+ * In this example, `[string, number]` and `string | number` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$extendsAll<[
+ *  string,
+ *  number,
+ * ], string | number>; // true
+ * ```
+ *
+ * @example
+ *
+ * In this example, `[unknown]` and `never` are passed as type arguments to the
+ * type-level function:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$extendsAll<[
+ *  unknown
+ * ], never>; // false
+ * ```
+ */
+export type _$extendsAll<
+  T extends List.List,
+  U extends unknown,
+  APPLY = $<$<List.Map, $<Conditional.Extends, U>>, T>,
+  RESULT extends boolean = APPLY extends boolean[]
+    ? $<$<$<List.Reduce, Boolean.And>, true>, APPLY>
+    : never
+> = RESULT
+
+interface ExtendsAll_T<T extends List.List> extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], unknown>): _$extendsAll<T, typeof x>
+}
+
+/**
+ * `ExtendsAll` is a type-level function that takes in an array of types, `T`, and a type `U`
+ * and return sa type-level function that returns `true` if all elements of `T` extend `U`,
+ * and `false` if otherwise.
+ *
+ * @param T An array of types.
+ * @param U A type.
+ *
+ * @example
+ *
+ * For example, we can use `ExtendsAll` to determine whether a series of types all extend a second input type.
+ * In this example, we partially apply `ExtendsAll` to `[string, number]`, which results in a
+ * type-level function that returns `true` if `string` and `number` both extend its input.
+ *
+ * We then apply this partially applied function to `string | number` and `never`
+ * respectively using the `$` type-level applicator:
+ *
+ * ```ts
+ * import { $, Conditional } from "hkt-toolbelt";
+ *
+ * type IsTrue = $<$<Conditional.ExtendsAll, [string, number]>, string | number>; // true
+ * type IsNotTrue = $<$<Conditional.ExtendsAll, [string, number]>, never>; // false
+ * ```
+ */
+export interface ExtendsAll extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], List.List>): ExtendsAll_T<typeof x>
+}

--- a/src/conditional/index.ts
+++ b/src/conditional/index.ts
@@ -1,5 +1,6 @@
 export * from "./equals";
 export * from "./equals-all";
 export * from "./extends";
+export * from "./extends-all";
 export * from "./if";
 export * from "./not-equals";

--- a/src/conditional/index.ts
+++ b/src/conditional/index.ts
@@ -1,4 +1,5 @@
 export * from "./equals";
+export * from "./equals-all";
 export * from "./extends";
 export * from "./if";
 export * from "./not-equals";


### PR DESCRIPTION
## Overview
- Generalizes `Conditional.Equals` and `Conditional.Extends` to lists of types. 
- `EqualsAll` compares all elements of the input list.
- `ExtendsAll` takes a second argument that serves as the basis of comparison.

```ts
// true
$<Conditional.EqualsAll, [PropertyKey, string | number | symbol, keyof any]>
// true
Conditional._$equalsAll<[
    $<$<$<List.Reduce, NaturalNumber.Add>, 0>, [1, 2, 3, 4, 5]>,
    $<$<NaturalNumber.Subtract, 20>, 5>,
    15
]>
```
```ts
// false
$<Conditional.ExtendsAll, string | boolean>, [string | number, string]>
// true
Conditional._$extendsAll<
    [{ a: 1 } & { b: 2 }, { a: 1 } & { c: 3 }], 
    { a: 1 },
>
```

## Details
- Optimized: both functions exit early when the first `false` evaluation is encountered.  
  - Faster than implementations using `List.Every` or map + reduce which run on `o(n)` time. 