### PR TITLE
Add List utility At

### DIFF
--- a/src/list/at.spec.ts
+++ b/src/list/at.spec.ts
@@ -1,0 +1,52 @@
+import { $, List, Test } from "hkt-toolbelt"
+
+type At_Spec = [
+  /**
+   * Can handle positive indices.
+   */
+  Test.Expect<$<$<List.At, 0>, ["a", "b", "c"]>, "a">,
+  Test.Expect<$<$<List.At, 1>, ["a", "b", "c"]>, "b">,
+  Test.Expect<$<$<List.At, 2>, ["a", "b", "c"]>, "c">,
+
+  /**
+   * Can handle negative indices.
+   */
+  Test.Expect<$<$<List.At, -1>, ["a", "b", "c"]>, "c">,
+  Test.Expect<$<$<List.At, -2>, ["a", "b", "c"]>, "b">,
+  Test.Expect<$<$<List.At, -3>, ["a", "b", "c"]>, "a">,
+
+  /**
+   * Overflow indices result in `never`
+   */
+  Test.Expect<$<$<List.At, 3>, ["a", "b", "c"]>, never>,
+  Test.Expect<$<$<List.At, -4>, ["a", "b", "c"]>, never>,
+
+  /**
+   * Empty arrays always return `never`.
+   */
+  Test.Expect<$<$<List.At, 0>, []>, never>,
+  Test.Expect<$<$<List.At, 1>, []>, never>,
+
+  /**
+   * Can handle nested arrays.
+   */
+  Test.Expect<$<$<List.At, 1>, [1, [2, [3]]]>, [2, [3]]>,
+  Test.Expect<$<$<List.At, 1>, [[1, 2], [3]]>, [3]>,
+  Test.Expect<$<$<List.At, 2>, [[1, 2], [3]]>, never>,
+
+  /**
+   * Can handle different element types.
+   */
+  Test.Expect<$<$<List.At, 0>, ["foo" | "bar", null, ["a"]]>, "foo" | "bar">,
+
+  /**
+   * Non-natural number N are not allowed.
+   */
+  Test.Expect<$<$<List.At, 1.5>, [1, 2, 3]>, never>,
+
+  /**
+   * Emits an error if being applied to a non-tuple.
+   */
+  // @ts-expect-error
+  $<$<List.At, 1>, number>
+]

--- a/src/list/at.ts
+++ b/src/list/at.ts
@@ -1,0 +1,40 @@
+import {
+  $,
+  Digit,
+  DigitList,
+  Kind,
+  Type,
+  Number,
+  List,
+  NaturalNumber,
+  Boolean,
+} from "../"
+
+export type _$at<
+  T extends List.List,
+  POS extends Number.Number,
+  T_LENGTH extends DigitList.DigitList = NaturalNumber._$toList<T["length"]>,
+  POS_ABS extends DigitList.DigitList = NaturalNumber._$toList<
+    Number._$absolute<POS>
+  >,
+  POS_NORM extends DigitList.DigitList = Number._$isNatural<POS> extends true
+    ? DigitList._$compare<POS_ABS, T_LENGTH> extends -1
+      ? POS_ABS
+      : never
+    : DigitList._$compare<T_LENGTH, POS_ABS> extends -1
+    ? never
+    : DigitList._$subtract<T_LENGTH, POS_ABS>,
+  INDEX extends number = DigitList._$toNumber<POS_NORM>
+> = POS_NORM extends never
+  ? never
+  : T[INDEX]
+
+interface At_T<X extends Number.Number> extends Kind.Kind {
+  f(
+    x: Type._$cast<this[Kind._], unknown[]>
+  ): Number._$isInteger<X> extends true ? _$at<typeof x, X> : never
+}
+
+export interface At extends Kind.Kind {
+  f(x: Type._$cast<this[Kind._], Number.Number>): At_T<typeof x>
+}

--- a/src/list/index.ts
+++ b/src/list/index.ts
@@ -1,3 +1,4 @@
+export * from "./at";
 export * from "./concat";
 export * from "./every";
 export * from "./flatten";


### PR DESCRIPTION
- Array element access with support for negative indices.
- Same functionality as ES2022's `Array.prototype.at`.
- Returns `never` for overflow indices i.e. if index < -array.length or index >= array.length

```ts
// "c"
$<$<List.At, -1>, ["a", "b", "c"]>
List._$at<["a", "b", "c"], -1>
```