### PR TITLE
Add test cases for various utilities

### DIFF
--- a/src/conditional/equals.spec.ts
+++ b/src/conditional/equals.spec.ts
@@ -29,5 +29,30 @@ type Equals_Spec = [
   /**
    * Never equals never.
    */
-  Test.Expect<$<$<Conditional.Equals, never>, never>>
+  Test.Expect<$<$<Conditional.Equals, never>, never>>,
+
+  /**
+   * Unknown equals unknown.
+   */
+  Test.Expect<$<$<Conditional.Equals, unknown>, unknown>>,
+
+  /**
+   * Deeply equals nested lists
+   */
+  Test.Expect<$<$<Conditional.Equals, [1, [2, [3, [4]]]]>, [1, [2, [3, [4]]]]>>,
+
+  /**
+   * Deeply equals nested objects
+   */
+  Test.Expect<$<$<Conditional.Equals, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [5, 6, 7], h: 8 | 9 | 10 } } }>, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [5, 6, 7], h: 8 | 9 | 10 } } }>>,
+  
+  /** 
+   * Equals empty lists and objects
+   */
+  Test.Expect<$<$<Conditional.Equals, []>, []>>,
+  Test.Expect<$<$<Conditional.Equals, [[]]>, [[]]>>,
+  Test.Expect<$<$<Conditional.Equals, {}>, {}>>,
+  Test.Expect<$<$<Conditional.Equals, {}>, object>>,
+  Test.Expect<$<$<Conditional.Equals, {}>, Record<PropertyKey, unknown>>>,
+  Test.Expect<$<$<Conditional.Equals, [{}]>, [{}]>>,
 ];

--- a/src/conditional/extends.spec.ts
+++ b/src/conditional/extends.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test } from "hkt-toolbelt";
+import { $, $$, $N, Kind, Conditional, Function, Test } from "hkt-toolbelt";
 
 type Extends_Spec = [
   /**
@@ -19,5 +19,61 @@ type Extends_Spec = [
   /**
    * number extends string => false
    */
-  Test.ExpectNot<$<$<Conditional.Extends, string>, number>>
+  Test.ExpectNot<$<$<Conditional.Extends, string>, number>>,
+
+  /**
+   * `unknown` extends `unknown`.
+   */
+  Test.Expect<$<$<Conditional.Extends, unknown>, unknown>>,
+
+  /**
+   * `never` extends `never`.
+   */
+  Test.Expect<$<$<Conditional.Extends, never>, never>>,
+
+  Test.Expect<
+    $<
+      $N<Conditional.If, [
+        $<Conditional.Extends, never>,
+        $<Function.Constant, true>,
+        $<Function.Constant, false>,
+      ]>, 
+      never
+    >,
+    true
+  >,
+
+  /**
+   * `never` extends everything, everything extends `unknown`.
+   */
+  Test.Expect<$<$<Conditional.Extends, string | number | boolean | symbol | object | unknown[]>, never>>,
+  Test.Expect<$<$<Conditional.Extends, unknown>, never>>,
+  Test.Expect<$<$<Conditional.Extends, unknown>, string | number | boolean | symbol | object | unknown[]>>,
+
+  /**
+   * Nothing extends `never`, `unknown` extends nothing.
+   */
+  Test.ExpectNot<$<$<Conditional.Extends, never>, string | number | boolean | symbol | object | unknown[]>>,
+  Test.ExpectNot<$<$<Conditional.Extends, never>, unknown>>,
+  Test.ExpectNot<$<$<Conditional.Extends, string | number | boolean | symbol | object | unknown[]>, unknown>>,
+
+  /**
+   * Deeply extends nested lists
+   */
+  Test.Expect<$<$<Conditional.Extends, [1, [2, [3, [4]]]]>, [1, [2, [3, [4]]]]>>,
+
+  /**
+   * Deeply extends nested objects
+   */
+  Test.Expect<$<$<Conditional.Extends, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [5, 6, 7], h: 8 | 9 | 10 } } }>, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [5, 6, 7], h: 8 | 9 | 10 } } }>>,
+  
+  /** 
+   * Extends empty lists and objects
+   */
+  Test.Expect<$<$<Conditional.Extends, []>, []>>,
+  Test.Expect<$<$<Conditional.Extends, [[]]>, [[]]>>,
+  Test.Expect<$<$<Conditional.Extends, {}>, {}>>,
+  Test.Expect<$<$<Conditional.Extends, {}>, object>>,
+  Test.Expect<$<$<Conditional.Extends, {}>, Record<PropertyKey, unknown>>>,
+  Test.Expect<$<$<Conditional.Extends, [{}]>, [{}]>>,
 ];

--- a/src/conditional/not-equals.spec.ts
+++ b/src/conditional/not-equals.spec.ts
@@ -29,5 +29,21 @@ type NotEquals_Spec = [
   /**
    * Never doesn't not equal never.
    */
-  Test.ExpectNot<$<$<Conditional.NotEquals, never>, never>>
+  Test.ExpectNot<$<$<Conditional.NotEquals, never>, never>>,
+
+  /**
+   * Deeply equals nested lists
+   */
+  Test.Expect<$<$<Conditional.NotEquals, [1, [2, [3, [4]]]]>, [1, [2, [3, [5]]]]>>,
+
+  /**
+   * Deeply equals nested objects
+   */
+  Test.Expect<$<$<Conditional.NotEquals, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [5, 6, 7], h: 8 | 9 | 10 } } }>, { a: 1, b: 2, c: { d: 3, e: { f: 4, g: [8, 9, 10], h: 5 | 6 | 7 } } }>>,
+  
+  /** 
+   * Equals empty lists and objects
+   */
+  Test.Expect<$<$<Conditional.NotEquals, []>, [[]]>>,
+  Test.Expect<$<$<Conditional.NotEquals, {}>, []>>,
 ]

--- a/src/kind/apply.spec.ts
+++ b/src/kind/apply.spec.ts
@@ -1,0 +1,63 @@
+import {
+  $,
+  $$,
+  $N,
+  Kind,
+  Function,
+  Conditional,
+  List,
+  String,
+  Test,
+} from "hkt-toolbelt"
+
+type Apply_Spec = [
+  /**
+   * Can apply kinds to types.
+   */
+  Test.Expect<$<$<Kind.Apply, number>, Function.Identity>, number>,
+
+  /**
+   * Can apply never
+   */
+  Test.Expect<$<$<Kind.Apply, never>, Function.Identity>, never>,
+  Test.Expect<
+    $<
+      $<Kind.Apply, never>, 
+      $N<Conditional.If, [
+        $<Conditional.Extends, never>,
+        $<Function.Constant, true>,
+        $<Function.Constant, false>,
+      ]>
+    >, 
+    true
+  >,
+
+  /**
+   * Can be used in its partially applied form.
+   */
+  Test.Expect<
+    $N<List.Map, [
+      $<
+        $<Kind.Apply, $<Function.Constant, null>>,
+        $N<Conditional.If, [
+          $<Conditional.Equals, 1>, 
+          Function.Identity
+        ]>
+      >,
+      $<List.Times, 3>
+    ]>,
+    [null, 1, null]
+  >,
+
+  /**
+   * $ enforces kind inputs.
+   */
+  // @ts-expect-error
+  $<$<Kind.Apply, number>, String.StartsWith<"foo">>,
+
+  /**
+   * $ will emit an error on non-kinds.
+   */
+  // @ts-expect-error
+  $<$<Kind.Apply, number>, number>
+]

--- a/src/list/map.spec.ts
+++ b/src/list/map.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, List, Test } from "hkt-toolbelt";
+import { $, $N, $$, Conditional, Function, List, Test } from "hkt-toolbelt";
 
 type Map_Spec = [
   /**
@@ -34,5 +34,22 @@ type Map_Spec = [
   Test.Expect<
     $<$<List.Map, $<Function.Constant, "foo">>, ["foo", "bar"]>,
     ["foo", "foo"]
-  >
+  >,
+
+  /** 
+   * Can be used in its partially applied form as an input for a higher-order map operation over nested tuples.
+   */
+  Test.Expect<
+    $N<List.Map, [
+      $<List.Map, 
+        $N<Conditional.If, [
+          $<Conditional.Equals, 1>, 
+          Function.Identity,
+          $<Function.Constant, null>
+        ]>
+      >,
+      $<$<List.Repeat, 2>, $<List.Times, 3>>
+    ]>,
+    [[null, 1, null], [null, 1, null]]
+  >,
 ];

--- a/src/list/repeat.spec.ts
+++ b/src/list/repeat.spec.ts
@@ -1,7 +1,5 @@
 import { $, Test, List } from ".."
 
-type TestType = string | number | undefined;
-
 type Repeat_Spec = [
   /**
    * Can create a tuple of length 0
@@ -20,9 +18,14 @@ type Repeat_Spec = [
   Test.Expect<$<$<List.Repeat, 5>, null>, [null, null, null, null, null]>,
 
   /**
+   * Correctly handles tuple type input.
+   */
+  Test.Expect<$<$<List.Repeat, 3>, $<List.Times, 3>>, [[0, 1, 2], [0, 1, 2], [0, 1, 2]]>,
+
+  /**
    * Correctly handles repeating union type input.
    */
-  Test.Expect<$<$<List.Repeat, 3>, TestType>, [string | number | undefined, string | number | undefined, string | number | undefined]>,
+  Test.Expect<$<$<List.Repeat, 3>, string | number | undefined>, [string | number | undefined, string | number | undefined, string | number | undefined]>,
 
   /**
    * Returns `never` for non-natural numbers.


### PR DESCRIPTION
- `Kind.Apply`: partial application as function input for `List.Map`
- `List.Map`: nested application on nested tuples with partial application as function input
- `Conditional.Equals`, `Conditional.NotEquals`, `Conditional.Extends`:
  - `never`, `unknown` relationships
  - Deeply nested tuples, objects
- `List.Repeat`: tuple type input