### PR TITLE
Add conditional util `Match` (pattern matching), `Contains` (converse of `extends`)

### DIFF
--- a/src/conditional/contains.spec.ts
+++ b/src/conditional/contains.spec.ts
@@ -1,0 +1,23 @@
+import { $, Conditional, Test } from "hkt-toolbelt";
+
+type Extends_Spec = [
+  /**
+   * T contains T (T extends T) => true
+   */
+  Test.Expect<$<$<Conditional.Contains, true>, true>>,
+
+  /**
+   * boolean contains true (true extends boolean) => true
+   */
+  Test.Expect<$<$<Conditional.Contains, true>, boolean>>,
+
+  /**
+   * true contains boolean (boolean extends true) => false
+   */
+  Test.ExpectNot<$<$<Conditional.Contains, boolean>, true>>,
+
+  /**
+   * number contains string (string extends number) => false
+   */
+  Test.ExpectNot<$<$<Conditional.Contains, string>, number>>
+];

--- a/src/conditional/contains.ts
+++ b/src/conditional/contains.ts
@@ -1,0 +1,89 @@
+import { $, $$, Conditional, Kind } from "..";
+
+/**
+ * `_$contains` is a type-level function that takes in two types, `T` and `X`,
+ * and returns a boolean value. `_$contains` will return `true` if `X` is a
+ * supertype of `T`, otherwise it returns `false`.
+ *
+ * This function checks the converse of `_$extends`. 
+ * While `_$extends` returns `true` if `X` -> `T` is true, 
+ * `_$contains` will return `true` if and only if `X` <- `T` is true.
+ * 
+ * This is useful if it is known that `T` extends `X`, 
+ * but the two arguments are being supplied in the opposite order expected by `_$extends`.
+ *
+ * ## Parameters
+ *
+ * @param T The subtype that we are checking if `X` contains.
+ * @param X The type that we are checking if it is a supertype of `T`.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `_$contains` to determine whether a type is a supertype
+ * of another type. In this example, we are checking whether the type `boolean` is
+ * a supertype of the type `true`:
+ *
+ * ```ts
+ * import { Conditional } from "hkt-toolbelt";
+ *
+ * type Result = Conditional._$contains<true, boolean>; // true
+ * ```
+ *
+ * Here, `boolean` is a supertype of `true`, so `_$contains` returns `true`.
+ */
+export type _$contains<T, X> = $$<[Conditional.Extends, $<Kind.Apply, T>], X>
+
+interface Contains_T<T> extends Kind.Kind {
+  f(x: this[Kind._]): _$contains<T, typeof x>;
+}
+
+/**
+ * `Contains` is a type-level function that takes in two types, `T` and `U`, and
+ * returns a boolean that represents whether `T` contains `U`.
+ * 
+ * This function checks the converse of `Extends`. 
+ * While `Extends` returns `true` if `T` -> `U` is true, 
+ * `Contains` will return `true` if and only if `T` <- `U` is true.
+ * 
+ * This is useful if it is known that `U` extends `T`, 
+ * but the two arguments are being supplied in the opposite order expected by `Extends`.
+ *
+ * ## Parameters
+ *
+ * @param T The supertype that we are checking if `U` extends.
+ * @param U The type that we are checking if it is a subtype of `T`.
+ *
+ * ## Example
+ *
+ * @example
+ *
+ * For example, we can use `Contains` to determine whether a type `T` contains a
+ * type `U`. In this example, we test whether `boolean` contains `true`:
+ *
+ * We apply `Contains` to `true` and `boolean` respectively using the `$`
+ * type-level applicator. This checks whether `boolean` contains `true`:
+ *
+ * ```ts
+ * import { $, Conditional } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Conditional.Contains, true>, boolean>; // true
+ * ```
+ *
+ * In the following examples, we test whether a number contains a string:
+ *
+ * ```ts
+ * import { $, Conditional } from "hkt-toolbelt";
+ *
+ * type Result = $<$<Conditional.Extends, number>, string>; // false
+ * ```
+ *
+ * Unlike `extends`, TypeScript does not provide a native keyword that can be used to
+ * perform a supertype check. While `extends` can only be used in a
+ * conditional type, `Contains` is composable, so it can be used in more
+ * sophisticated type-level functions.
+ */
+export interface Contains extends Kind.Kind {
+  f(x: this[Kind._]): Contains_T<typeof x>;
+}

--- a/src/conditional/index.ts
+++ b/src/conditional/index.ts
@@ -1,3 +1,4 @@
+export * from "./contains";
 export * from "./equals";
 export * from "./extends";
 export * from "./if";


### PR DESCRIPTION
## `Conditional.Contains`
Performs supertype check (converse of `extends`)
- Ideas for better name? `Subsumes`, `Generalizes`, `Widens`, ...
```ts
$<$<Conditional.Contains, "A">, "A" | "B">  // true
Conditional._$contains<true, boolean>  // true
```

## `Conditional.Match` (WIP)
Notes:
```ts
type MatchAThenBThenC = 
    $N<Conditional.If, [
        $<Contains, "A">,
        $<Function.Constant, "It's an A!">,
        $N<Conditional.If, [
            $<Contains, "B">,
            $<Function.Constant, "It's a B!">,
            $N<Conditional.If, [
                $<Contains, "C">,
                $<Function.Constant, "It's a C!">,
                $<Function.Constant, never>,
            ]>,
        ]>,
    ]>

type _ = $<MatchAThenBThenC, "A" | "B">  // "It's an A!"
type _ = $<MatchAThenBThenC, "B" | "C">  // "It's a B!"
type _ = $<MatchAThenBThenC, "C" | "D">. // "It's a C!"
type _ = $<MatchAThenBThenC, "E" | "F">. // never
```