### PR TITLE
Batch formatting, import statement changes

### DIFF
--- a/src/$/$$.spec.ts
+++ b/src/$/$$.spec.ts
@@ -1,4 +1,4 @@
-import { $, $$, String, Test, List, Kind } from "hkt-toolbelt";
+import { $, $$, String, Test, List, Kind } from "..";
 
 type $$_Spec = [
   /**

--- a/src/$/$$.ts
+++ b/src/$/$$.ts
@@ -48,17 +48,12 @@ import { Kind, List } from "..";
  * Here, `$$` is being used to pipe `List.Push` and `String.Join` together and
  * then apply them to a list of strings.
  *
- * ## Parameters
- *
  * @param FX A tuple of type-level functions that will be piped together.
  * @param X The input type that the type-level functions will be applied to.
- *
- * ## Examples
  *
  * ### Basic Usage
  *
  * @example
- *
  * Here's a basic example that uses `$$` to apply a type-level function to an
  * input type:
  *

--- a/src/$/$.spec.ts
+++ b/src/$/$.spec.ts
@@ -1,4 +1,4 @@
-import { $, $$, Function, String, Test } from "hkt-toolbelt";
+import { $, $$, Function, String, Test } from "..";
 
 type $_Spec = [
   /**

--- a/src/$/$.ts
+++ b/src/$/$.ts
@@ -29,18 +29,13 @@ import { Kind, Function } from "..";
  * If we wanted to create a 'Map' type, we would not be able to do so with
  * normal generic type parameters. Instead, we would need to use a higher-order
  * type-level function. That is what `hkt-toolbelt` provides.
- * 
- * ## Parameters
- * 
+ *
  * @param F A type-level function.
  * @param X The input type to apply the type-level function to.
- * 
- * ## Examples
- * 
+ *
  * ### Basic Usage
  * 
  * @example
- * 
  * For example, `Function.Identity` is a type-level function which takes in one
  * argument: the input type. `Function.Identity` returns the input type that was
  * passed in.
@@ -54,7 +49,6 @@ import { Kind, Function } from "..";
  * ```
  * 
  * @example
- * 
  * For example, `String.Append` is a type-level function which takes in two
  * arguments: first, the string to append, and second, the string to append to.
  * 
@@ -79,7 +73,6 @@ import { Kind, Function } from "..";
  * ### Advanced Usage
  * 
  * @example
- * 
  * For example, `List.Map` is a type-level function which takes in two
  * arguments: first, a type-level function, and second, a list. `List.Map`
  * returns a list of the same length as the input list, where each element is
@@ -102,7 +95,6 @@ import { Kind, Function } from "..";
  * achieved with normal generic type parameters.
  * 
  * @example
- * 
  * For example, `List.Filter` is a type-level function which takes in two
  * arguments: first, a type-level function, and second, a list. `List.Filter`
  * will only return the elements of the input list where the type-level

--- a/src/$/$N.ts
+++ b/src/$/$N.ts
@@ -18,7 +18,6 @@ import { Kind } from ".."
  * such as conditionals.
  *
  * @example
- *
  * For example, `Function.If` is a type-level function which takes in four
  * arguments: a predicate, a truthy branch, a falsy branch, and an input type.
  *

--- a/src/boolean/and.spec.ts
+++ b/src/boolean/and.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type And_Spec = [
   /**

--- a/src/boolean/and.ts
+++ b/src/boolean/and.ts
@@ -6,15 +6,10 @@ import { Kind, Type } from "..";
  * on `T` and `U`. If both `T` and `U` are true, then `_$and` returns true,
  * otherwise it returns false.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$and` to determine whether two boolean types are
  * both true. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:
@@ -45,7 +40,6 @@ interface And_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `And` to determine whether two boolean types are
  * both true. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:

--- a/src/boolean/imply.spec.ts
+++ b/src/boolean/imply.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Imply_Spec = [
   /**

--- a/src/boolean/imply.ts
+++ b/src/boolean/imply.ts
@@ -8,15 +8,10 @@ import { Kind, Type } from "..";
  *
  * This is also known as the 'logical implication' operator.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$imply` to determine whether a statement is true
  * given the truth values of two propositions, `T` and `U`. In this example,
  * `true` and `false` are passed as type arguments to the type-level function:
@@ -49,7 +44,6 @@ interface Imply_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Imply` to determine whether a statement is true
  * given the truth values of two propositions, `T` and `U`. In this example,
  * `true` and `false` are passed as type arguments to the type-level function:

--- a/src/boolean/nand.spec.ts
+++ b/src/boolean/nand.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Nand_Spec = [
   /**

--- a/src/boolean/nand.ts
+++ b/src/boolean/nand.ts
@@ -6,15 +6,10 @@ import { Type, Kind } from "..";
  * on `T` and `U`. If both `T` and `U` are true, then `_$nand` returns false,
  * otherwise it returns true.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$nand` to determine whether two boolean types are
  * not both true. In this example, `true` and `false` are passed as type
  * arguments to the type-level function:
@@ -45,7 +40,6 @@ interface Nand_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Nand` to determine whether two boolean types are
  * not both true. In this example, `true` and `false` are passed as type
  * arguments to the type-level function:

--- a/src/boolean/nimply.spec.ts
+++ b/src/boolean/nimply.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Nimply_Spec = [
   /**

--- a/src/boolean/nimply.ts
+++ b/src/boolean/nimply.ts
@@ -6,15 +6,10 @@ import { Kind, Type } from "..";
  * operation on `T` and `U`. If `T` is true and `U` is false, then `_$nimply`
  * returns true, otherwise it returns false.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$nimply` to determine whether two boolean types
  * follow the 'not-implies' logical operation. In this example, `true` and
  * `false` are passed as type arguments to the type-level function:
@@ -45,7 +40,6 @@ interface Nimply_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Nimply` to determine whether two boolean types
  * follow the 'not-implies' logical operation. In this example, `true` and
  * `false` are passed as type arguments to the type-level function:

--- a/src/boolean/nor.spec.ts
+++ b/src/boolean/nor.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Nor_Spec = [
   /**

--- a/src/boolean/nor.ts
+++ b/src/boolean/nor.ts
@@ -6,15 +6,10 @@ import { Type, Kind } from "..";
  * on `T` and `U`. If both `T` and `U` are false, then `_$nor` returns true,
  * otherwise it returns false.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$nor` to determine whether two boolean types are
  * both false. In this example, `true` and `true` are passed as type arguments
  * to the type-level function:
@@ -45,7 +40,6 @@ interface Nor_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Nor` to determine whether two boolean types are both
  * false. In this example, `true` and `true` are passed as type arguments to the
  * type-level function:

--- a/src/boolean/not.spec.ts
+++ b/src/boolean/not.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Not_Spec = [
   /**

--- a/src/boolean/not.ts
+++ b/src/boolean/not.ts
@@ -5,14 +5,9 @@ import { Type, Kind } from "..";
  * returns the boolean result of applying the 'not' logical operation on `T`.
  * If `T` is true, then `_$not` returns false, otherwise it returns true.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$not` to negate a boolean type:
  *
  * ```ts
@@ -30,7 +25,6 @@ export type _$not<T extends boolean> = T extends true ? false : true;
  * @param T A boolean type.
  *
  * @example
- *
  * For example, we can use `Not` to negate a boolean type:
  *
  * We apply `Not` to `true` using the `$` type-level applicator:

--- a/src/boolean/or.spec.ts
+++ b/src/boolean/or.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Or_Spec = [
   /**

--- a/src/boolean/or.ts
+++ b/src/boolean/or.ts
@@ -6,15 +6,10 @@ import { Type, Kind } from "..";
  * on `T` and `U`. If either `T` or `U` is true, then `_$or` returns true,
  * otherwise it returns false.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$or` to determine whether at least one of two boolean
  * types is true. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:
@@ -45,7 +40,6 @@ interface Or_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Or` to determine whether at least one of two boolean
  * types is true. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:

--- a/src/boolean/xnor.spec.ts
+++ b/src/boolean/xnor.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Xnor_Spec = [
   /**

--- a/src/boolean/xnor.ts
+++ b/src/boolean/xnor.ts
@@ -6,15 +6,10 @@ import { Type, Kind } from "..";
  * on `T` and `U`. If `T` and `U` are equal, then `_$xnor` returns true,
  * otherwise it returns false.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `_$xnor` to determine whether two boolean types are
  * equal. In this example, `true` and `true` are passed as type arguments to the
  * type-level function:
@@ -26,7 +21,6 @@ import { Type, Kind } from "..";
  * ```
  *
  * @example
- *
  * In this example, `true` and `false` are passed as type arguments to the
  * type-level function:
  *
@@ -53,7 +47,6 @@ interface Xnor_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Xnor` to determine whether two boolean types are
  * equal. In this example, `true` and `true` are passed as type arguments to the
  * type-level function:
@@ -68,7 +61,6 @@ interface Xnor_T<T extends boolean> extends Kind.Kind {
  * ```
  *
  * @example
- *
  * In this example, `true` and `false` are passed as type arguments to the
  * type-level function:
  *

--- a/src/boolean/xor.spec.ts
+++ b/src/boolean/xor.spec.ts
@@ -1,4 +1,4 @@
-import { $, Boolean, Test } from "hkt-toolbelt";
+import { $, Boolean, Test } from "..";
 
 type Xor_Spec = [
   /**

--- a/src/boolean/xor.ts
+++ b/src/boolean/xor.ts
@@ -6,15 +6,10 @@ import { Type, Kind } from "..";
  * logical operation on `T` and `U`. If `T` and `U` are the same, then
  * `_$xor` returns false, otherwise it returns true.
  *
- * ## Parameters
- *
  * @param T A boolean type.
  * @param U A boolean type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$xor` to determine whether two boolean types are
  * different. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:
@@ -42,7 +37,6 @@ interface Xor_T<T extends boolean> extends Kind.Kind {
  * @param U A boolean type.
  *
  * @example
- *
  * For example, we can use `Xor` to determine whether two boolean types are
  * different. In this example, `true` and `false` are passed as type arguments
  * to the type-level function:

--- a/src/combinator/apply-self.spec.ts
+++ b/src/combinator/apply-self.spec.ts
@@ -1,4 +1,4 @@
-import { $, Combinator, Function, String, Test } from "hkt-toolbelt";
+import { $, Combinator, Function, String, Test } from "..";
 
 type ApplySelf_Spec = [
   /**

--- a/src/combinator/apply-self.ts
+++ b/src/combinator/apply-self.ts
@@ -11,14 +11,9 @@ import { $, Type, Kind, Combinator } from "..";
  * where the function `f` takes in itself as an argument, and returns its own
  * application to itself.
  *
- * ## Parameters
- *
  * @param F A recursive kind that takes in itself as a type argument.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `ApplySelf` to create the omega combinator, which
  * is the simplest way to cause an infinite loop in term-rewriting systems.
  *
@@ -29,7 +24,6 @@ import { $, Type, Kind, Combinator } from "..";
  * ```
  *
  * @example
- *
  * For example, you could apply `ApplySelf` to the identity function. This
  * returns the identity function itself, so is of little practical use.
  *

--- a/src/combinator/collate.ts
+++ b/src/combinator/collate.ts
@@ -54,7 +54,6 @@ export type _$collate<N extends number> = N extends 0 ? [] : _$collate2<N>
  * If zero is passed in, an empty tuple is immediately returned.
  *
  * @example
- *
  * ```ts
  * import { $, Kind, Type } from "ts-toolbelt"
  *

--- a/src/combinator/fix-sequence.ts
+++ b/src/combinator/fix-sequence.ts
@@ -25,8 +25,6 @@ import { $, Type, Kind } from "..";
  * fixed-point sequence. This is optional and defaults to an array containing
  * the initial `VALUE`.
  *
- * ## Examples
- *
  * ### Term Rewriting
  *
  * Here we show a simple example of a convergent fixed-point sequence. Term
@@ -134,8 +132,6 @@ interface FixSequence_T<KIND extends Kind.Kind> extends Kind.Kind {
  *
  * If convergence is not reached, the 'infinite type instantiation' error will
  * be emitted by the TypeScript compiler.
- *
- * ## Examples
  *
  * ### Term Rewriting
  *

--- a/src/combinator/self.spec.ts
+++ b/src/combinator/self.spec.ts
@@ -1,4 +1,4 @@
-import { $, Combinator, Test } from "hkt-toolbelt";
+import { $, Combinator, Test } from "..";
 
 type Self_Spec = [
   /**

--- a/src/combinator/self.ts
+++ b/src/combinator/self.ts
@@ -4,8 +4,6 @@ import { Kind } from "..";
  * `Self` is a higher-order type-level function that outputs itself. Since it
  * outputs itself, it can be applied an arbitrary amount of times.
  *
- * ## Example
- *
  * ```ts
  * import { $, Combinator } from "hkt-toolbelt";
  *

--- a/src/conditional/equals-all.spec.ts
+++ b/src/conditional/equals-all.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test, List, NaturalNumber } from "hkt-toolbelt"
+import { $, Conditional, Test, List, NaturalNumber } from "..";
 
 type EqualsAll_Spec = [
   /**

--- a/src/conditional/equals-all.ts
+++ b/src/conditional/equals-all.ts
@@ -4,15 +4,10 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * `_$equalsAll` is a type-level function that takes in an array of types `T`,
  * and returns `true` if all elements of `T` are equal or `T` is empty.
  *
- * ## Parameters
- *
  * @param T An array of types.
  * @param U A type.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `_$equalsAll` to determine whether a series of types are equal.
  * In this example, `[false, false, false]` is passed as a type argument to the
  * type-level function:
@@ -27,7 +22,6 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * ]>; // true
  *
  * @example
- *
  * For example, we can use `_$equalsAll` to determine whether a series of type expressions are all equal to a second input type.
  * In this example, `[true, true]` and `unknown` are passed as type arguments to the
  * type-level function:
@@ -42,7 +36,6 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * ```
  *
  * @example
- *
  * In this example, `[string | number | symbol, keyof any]` and `PropertyKey` are passed as type arguments to the
  * type-level function:
  *
@@ -72,7 +65,6 @@ export type _$equalsAll<
  * @param T An array of types.
  *
  * @example
- *
  * For example, we can use `EqualsAll` to determine whether multiple types are equal.
  * In this example, `EqualsAll` is a type-level function that returns `true` if all elements of its input evaluate as being equal.
  *

--- a/src/conditional/equals.spec.ts
+++ b/src/conditional/equals.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test } from "hkt-toolbelt";
+import { $, Conditional, Test } from "..";
 
 type Equals_Spec = [
   /**

--- a/src/conditional/equals.ts
+++ b/src/conditional/equals.ts
@@ -4,15 +4,10 @@ import { Kind } from "..";
  * `_$equals` is a type-level function that takes in two types, `T` and `U`, and
  * returns `true` if `T` and `U` are the same type, and `false` otherwise.
  *
- * ## Parameters
- *
  * @param T A type.
  * @param U A type.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `_$equals` to determine whether two types are equal.
  * In this example, `true` and `true` are passed as type arguments to the
  * type-level function:
@@ -24,7 +19,6 @@ import { Kind } from "..";
  * ```
  *
  * @example
- *
  * In this example, `true` and `false` are passed as type arguments to the
  * type-level function:
  *
@@ -49,7 +43,6 @@ interface Equals_T<T> extends Kind.Kind {
  * @param U A type.
  *
  * @example
- *
  * For example, we can use `Equals` to determine whether two types are equal.
  * In this example, we partially apply `Equals` to `true`, which results in a
  * type-level function that returns `true` if its input is the same as `true`.

--- a/src/conditional/extends-all.spec.ts
+++ b/src/conditional/extends-all.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test } from "hkt-toolbelt"
+import { $, Conditional, Test } from "..";
 
 class Animal {
   name: string

--- a/src/conditional/extends-all.ts
+++ b/src/conditional/extends-all.ts
@@ -5,15 +5,10 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * and returns `true` if and only if all elements of `T` extend `U`, or `T` is empty.
  * Otherwise it returns `false`.
  *
- * ## Parameters
- *
  * @param T An array of types.
  * @param U A type.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `_$extendsAll` to determine whether a series of type expressions all extend a second input type.
  * In this example, `[true, false]` and `boolean` are passed as type arguments to the
  * type-level function:
@@ -28,7 +23,6 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * ```
  *
  * @example
- *
  * For example, we can use `_$extendsAll` to determine whether a series of types all extend the second input type.
  * In this example, `[string, number]` and `string | number` are passed as type arguments to the
  * type-level function:
@@ -43,7 +37,6 @@ import { $, Type, Kind, List, Conditional, Boolean } from ".."
  * ```
  *
  * @example
- *
  * In this example, `[unknown]` and `never` are passed as type arguments to the
  * type-level function:
  *
@@ -79,7 +72,6 @@ interface ExtendsAll_T<U extends unknown> extends Kind.Kind {
  * @param T An array of types.
  *
  * @example
- *
  * For example, we can use `ExtendsAll` to determine whether a series of types all extend a second input type.
  * In this example, we partially apply `ExtendsAll` to `string | number` and `never`, which result in
  * two type-level functions that return `true` if all elements of their input extend `string | number` and `never`, respectively.

--- a/src/conditional/extends.spec.ts
+++ b/src/conditional/extends.spec.ts
@@ -1,4 +1,4 @@
-import { $, $$, $N, Kind, Conditional, Function, Test } from "hkt-toolbelt";
+import { $, $$, $N, Kind, Conditional, Function, Test } from "..";
 
 type Extends_Spec = [
   /**

--- a/src/conditional/extends.ts
+++ b/src/conditional/extends.ts
@@ -11,15 +11,10 @@ import { Kind } from "..";
  * ensures that we are only checking if `X` is a subtype of `T`, rather than
  * checking if `T` is a subtype of `X`.
  *
- * ## Parameters
- *
  * @param T The supertype that we are checking if `X` extends.
  * @param X The type that we are checking if it is a subtype of `T`.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$extends` to determine whether a type is a subtype
  * of another type. In this example, we are checking whether the type `true` is
  * a subtype of the type `boolean`:
@@ -44,15 +39,10 @@ interface Extends_T<T> extends Kind.Kind {
  * `Extends` is a type-level function that takes in two types, `T` and `U`, and
  * returns a boolean that represents whether `T` extends `U`.
  *
- * ## Parameters
- *
  * @param T The supertype that we are checking if `U` extends.
  * @param U The type that we are checking if it is a subtype of `T`.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `Extends` to determine whether a type `T` extends a
  * type `U`. In this example, we test whether `true` extends `boolean`:
  *

--- a/src/conditional/if.ts
+++ b/src/conditional/if.ts
@@ -8,8 +8,6 @@ import { $, Type, Kind } from ".."
  *
  * This can be thought of as a type-level ternary operator.
  *
- * ## Parameters
- *
  * @param Predicate A type-level function of the form `(x: never) => boolean`.
  * @param Then A type-level function that is applied on the truthy branch.
  * @param Else A type-level function that is applied on the falsy branch.
@@ -56,8 +54,6 @@ interface If_T1<Predicate extends Kind.Kind<(x: never) => boolean>>
  *
  * This can be thought of as a type-level ternary operator.
  *
- * ## Parameters
- *
  * @param Predicate A type-level function of the form `(x: never) => boolean`.
  * @param Then A type-level function that is applied when the predicate returns
  * `true`.
@@ -68,7 +64,6 @@ interface If_T1<Predicate extends Kind.Kind<(x: never) => boolean>>
  * ## Usage Examples
  *
  * @example
- *
  * For example, we can use `If` to create a type-level ternary operator. Since
  * `If` has a high arity, we use `$N` to pipe multiple arguments to `If`.
  *
@@ -99,7 +94,6 @@ interface If_T1<Predicate extends Kind.Kind<(x: never) => boolean>>
  * on the input string, so more complex processing can be done in the branches.
  *
  * @example
- *
  * We can also use `If` to filter a list. In this example, we use
  * `String.StartsWith` to filter out elements of a list that do not start with
  * the string "foo":

--- a/src/conditional/is-supertype-of.spec.ts
+++ b/src/conditional/is-supertype-of.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test } from "hkt-toolbelt";
+import { $, Conditional, Test } from "..";
 
 type Extends_Spec = [
   /**

--- a/src/conditional/is-supertype-of.ts
+++ b/src/conditional/is-supertype-of.ts
@@ -12,15 +12,10 @@ import { $, $$, Conditional, Kind } from "..";
  * This is useful if it is known that `T` extends `X`, 
  * but the two arguments are being supplied in the opposite order expected by `_$extends`.
  *
- * ## Parameters
- *
  * @param T The subtype that we are checking if `X` is a supertype of.
  * @param X The type that we are checking if it is a supertype of `T`.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$isSupertypeOf` to determine whether a type is a supertype
  * of another type. In this example, we are checking whether the type `boolean` is
  * a supertype of the type `true`:
@@ -50,16 +45,11 @@ interface IsSupertypeOf_T<T> extends Kind.Kind {
  * This is useful if it is known that `U` extends `T`, 
  * but the two arguments are being supplied in the opposite order expected by `Extends`.
  *
- * ## Parameters
- *
  * @param T The supertype that we are checking if `U` extends.
  * @param U The type that we are checking if it is a subtype of `T`.
  *
- * ## Example
- *
  * @example
- *
- * For example, we can use `IsSupertypeOf` to determine whether a given type `T` is a supertype of 
+ * For example, we can use `IsSupertypeOf` to determine whether a given type `T` is a supertype of
  * another type `U`. In this example, we test whether `boolean` is a supertype of `true`:
  *
  * We apply `IsSupertypeOf` to `true` and `boolean` respectively using the `$`

--- a/src/conditional/match.ts
+++ b/src/conditional/match.ts
@@ -1,0 +1,135 @@
+import {
+  $,
+  $$,
+  $N,
+  Kind,
+  Type,
+  Function,
+  Conditional,
+  List,
+  Object,
+  String,
+  Test,
+} from "hkt-toolbelt"
+
+interface LocationSchema {
+  city: string
+  country: string
+  postcode: number | string
+  coordinates: {
+    latitude: `${"-" | ""}${number}.${number}`
+    longitude: `${"-" | ""}${number}.${number}`
+  }
+  timezone: {
+    offset: `${"+" | "-"}${number}:${0 | 3}0`
+    description?: string
+  }
+}
+
+type RawResponses = [
+  {
+    city: "Amiens"
+    country: "France"
+    postcode: "^$�deY�8V�"
+    coordinates: { latitude: "�`y�xe��Բ"; longitude: "173.1494" }
+    timezone: { offset: "�[-no�F�>~�A"; description: "Adelaide, Darwin" }
+  },
+  {
+    city: "Summerside"
+    country: "Canada"
+    postcode: "V8E 7Q2"
+    coordinates: { latitude: "-72.1531"; longitude: "-155.1383" }
+    timezone: { offset: "-4:00" }
+  },
+  {
+    city: "Essertines-sur-Yverdon"
+    country: "Switzerland"
+    postcode: 3045
+    coordinates: { latitude: "-57.5622"; longitude: "75.3632" }
+    timezone: { offset: "-4:00" }
+  },
+  {
+    status: "403"
+    source: { pointer: "/data/attributes/secretPowers" }
+    detail: "Editing secret powers is not authorized on Sundays."
+  },
+  {
+    city: "Sviland"
+    country: "Norway"
+    postcode: "1215"
+    coordinates: { latitude: "38.6709"; longitude: "95.1991" }
+    timezone: { offset: "+3:30"; description: "Tehran" }
+  },
+  {
+    status: "500"
+    source: { pointer: "/data/attributes/reputation" }
+    title: "The backend responded with an error"
+    detail: "Reputation service not responding after three requests."
+  }
+]
+
+type ValidResponses = [
+  {
+    city: "Summerside"
+    country: "Canada"
+    postcode: "V8E 7Q2"
+    coordinates: { latitude: "-72.1531"; longitude: "-155.1383" }
+    timezone: { offset: "-4:00" }
+  },
+  {
+    city: "Essertines-sur-Yverdon"
+    country: "Switzerland"
+    postcode: 3045
+    coordinates: { latitude: "-57.5622"; longitude: "75.3632" }
+    timezone: { offset: "-4:00" }
+  },
+  {
+    city: "Sviland"
+    country: "Norway"
+    postcode: "1215"
+    coordinates: { latitude: "38.6709"; longitude: "95.1991" }
+    timezone: { offset: "+3:30"; description: "Tehran" }
+  }
+]
+
+type ExtendsSchema = $<Conditional.Extends, LocationSchema>
+
+type _ = [
+  Test.Expect<
+    $N<List.Every, [ExtendsSchema, RawResponses]>,
+    false
+  >,
+
+  Test.Expect<
+    $N<List.Filter, [ExtendsSchema, RawResponses]>, 
+    ValidResponses
+  >,
+
+  Test.Expect<
+    $$<
+      [
+        $<List.Filter, ExtendsSchema>,  // ValidResponses
+
+        Kind.Apply,  // $<Kind.Apply, ValidResponses>
+        List.Map,    // $<List.Map, $<Kind.Apply, ValidResponses>>
+
+        $<Kind.Apply, 
+          $N<List.Map, [
+            List.Map, 
+            [$<Object.At, "city">, $<Object.At, "country">]
+          ]>  // $<Kind.Apply, [$<List.Map, $<Object.At, "city">>, $<List.Map, $<Object.At, "country">>]>
+        >,  //  $N<List.Map, [$<Kind.Apply, ValidResponses>, $<Kind.Apply, [$<List.Map, $<Object.At, "city">>, $<List.Map, $<Object.At, "country">>]>]>
+        // [["Summerside", "Essertines-sur-Yverdon", "Sviland"], ["Canada", "Switzerland", "Norway"]]
+
+        List.Zip, // [["Summerside", "Canada"], ["Essertines-sur-Yverdon", "Switzerland"], ["Sviland", "Norway"]]
+
+        $<List.Map, $<String.Join, ", ">>,  // ["Summerside, Canada", "Essertines-sur-Yverdon, Switzerland", "Sviland, Norway"]
+
+        // $<$<List.Reduce, String.FromList>, "">
+      ],
+      RawResponses
+    >,
+    ["Summerside, Canada", "Essertines-sur-Yverdon, Switzerland", "Sviland, Norway"]
+    // "Summerside, Canada; Essertines-sur-Yverdon, Switzerland; Sviland, Norway; "
+  >
+]

--- a/src/conditional/not-equals.spec.ts
+++ b/src/conditional/not-equals.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Test } from "hkt-toolbelt"
+import { $, Conditional, Test } from "..";
 
 type NotEquals_Spec = [
   /**

--- a/src/conditional/not-equals.ts
+++ b/src/conditional/not-equals.ts
@@ -8,7 +8,6 @@ import { Kind } from ".."
  * @param U The second type to compare.
  *
  * @example
- *
  * In this example, `true` and `false` are passed as type arguments to the
  * type-level function:
  *

--- a/src/digit-list/add.ts
+++ b/src/digit-list/add.ts
@@ -23,15 +23,10 @@ type _$add2<
  * `_$add` is a type-level function that takes in two digit lists `A` and `B`,
  * and returns the sum of the two digit lists as a new digit list.
  *
- * ## Parameters
- *
  * @param A A digit list.
  * @param B A digit list.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$add` to add two digit lists representing the
  * numbers 123 and 456:
  *
@@ -60,7 +55,6 @@ interface Add_T<X extends DigitList.DigitList> extends Kind.Kind {
  * @param B A digit list.
  *
  * @example
- *
  * For example, we can use `Add` to add two digit lists representing the
  * numbers 123 and 456:
  *

--- a/src/digit-list/compare.ts
+++ b/src/digit-list/compare.ts
@@ -36,15 +36,10 @@ type _$compare2<
  * 1 if `A` is greater than `B`, 0 if `A` is equal to `B`, and -1 if `A` is
  * less than `B`.
  *
- * ## Parameters
- *
  * @param A A digit list type.
  * @param B A digit list type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$compare` to compare two digit lists. In this
  * example, we compare the digit lists ["1", "2", "3"] and ["3", "2", "1"]:
  *
@@ -83,8 +78,7 @@ interface Compare_T<X extends DigitList.DigitList> extends Kind.Kind {
  * @param B A digit list type.
  *
  * @example
- *
- * For example, we can use the `$` type-level applicator to apply `Compare` to two digit lists. 
+ * For example, we can use the `$` type-level applicator to apply `Compare` to two digit lists.
  * In this example, we compare the digit lists ["1", "2", "3"] and ["3", "2", "1"]:
  *
  * ```ts

--- a/src/digit-list/decrement.ts
+++ b/src/digit-list/decrement.ts
@@ -28,14 +28,9 @@ type _$decrement2<
  * digit list by 1. If the input digit list is empty or represents zero, the
  * result will be a digit list representing zero.
  *
- * ## Parameters
- *
  * @param A A digit list type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$decrement` to decrement a digit list representing
  * the number 42 by 1. In this example, the digit list `["4", "2"]` is passed as
  * a type argument to the type-level function:
@@ -47,7 +42,6 @@ type _$decrement2<
  * ```
  *
  * @example
- *
  * We can also use `_$decrement` with an empty digit list or a digit list
  * representing zero. In both cases, the result will be a digit list
  * representing zero:
@@ -69,14 +63,9 @@ export type _$decrement<A extends DigitList.DigitList> = DigitList._$trim<
  * digit list by 1. If the input digit list is empty or represents zero, the
  * result will be a digit list representing zero.
  *
- * ## Parameters
- *
  * @param A A digit list type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `Decrement` to decrement a digit list representing
  * the number 42 by 1. In this example, the digit list `["4", "2"]` is passed as
  * a type argument to the type-level function:
@@ -88,7 +77,6 @@ export type _$decrement<A extends DigitList.DigitList> = DigitList._$trim<
  * ```
  *
  * @example
- *
  * We can also use `Decrement` with an empty digit list or a digit list
  * representing zero. In both cases, the result will be a digit list
  * representing zero:

--- a/src/digit-list/digit-list.ts
+++ b/src/digit-list/digit-list.ts
@@ -3,17 +3,14 @@ import { Digit } from "..";
 /**
  * `DigitList` is a type alias representing a list of decimal digits from "0" to "9" (inclusive).
  *
- * ## Example
- *
  * @example
+ * For example, we can use `DigitList` to represent a list of decimal digits from "0" to "9":
  *
-* For example, we can use `DigitList` to represent a list of decimal digits from "0" to "9":
-*
-* ```ts
-* import { DigitList } from "hkt-toolbelt";
-*
-* type MyDigitList = DigitList; // ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")[]
-* ```
-*
-*/
+ * ```ts
+ * import { DigitList } from "hkt-toolbelt";
+ *
+ * type MyDigitList = DigitList; // ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")[]
+ * ```
+ *
+ */
 export type DigitList = readonly Digit.Digit[];

--- a/src/digit-list/divide-by-subtraction.ts
+++ b/src/digit-list/divide-by-subtraction.ts
@@ -38,7 +38,6 @@ type _$divideBySubtraction2<
  * @param OPERATION A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
  *
  * @example
- *
  * For example, we can use `_$divideBySubtraction` to divide a digit list representing the number 10 by 2:
  *
  * ```ts
@@ -48,7 +47,6 @@ type _$divideBySubtraction2<
  * ```
  *
  * @example
- *
  * We can also use `_$divideBySubtraction` to find the remainder when a digit list representing the number 123 is divided by 17:
  *
  * ```ts
@@ -81,13 +79,10 @@ interface DivideBySubtraction_T<A extends DigitList.DigitList>
  * `DivideBySubtraction` is a type-level function that performs a division by subtraction.
  * It returns the result of the division.
  *
- * ## Parameters
- * 
  * @param A A digit list representing a number to divide.
  * @param B A digit list representing a number to divide by.
  *
  * @example
- *
  * For example, we can use `DivideBySubtraction` to divide a digit list representing the number 10 by 2:
  *
  * ```ts

--- a/src/digit-list/divide.ts
+++ b/src/digit-list/divide.ts
@@ -93,14 +93,11 @@ type _$divide2<
  * which can be either "DIVIDE" or "MODULO". It checks if the divisor is 0 or 1 and returns the appropriate result.
  * If the divisor is neither 0 nor 1, it calls the `_$divide2` function to perform the division.
  *
- * ## Parameters
- * 
  * @param A A digit list representing a number to divide.
  * @param B A digit list representing a number to divide by.
  * @param OPERATION A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
  *
  * @example
- *
  * For example, we can use `_$divide` to divide a digit list representing the number 10 by 2:
  *
  * ```ts
@@ -110,7 +107,6 @@ type _$divide2<
  * ```
  *
  * @example
- *
  * We can also use `_$divide` to find the remainder when a digit list representing the number 123 is divided by 17:
  *
  * ```ts
@@ -140,7 +136,6 @@ interface Divide_T<A extends DigitList.DigitList> extends Kind.Kind {
  * It returns the result of the division operation.
  *
  * @example
- *
  * For example, we can use `Divide` to create a division operation that divides a digit list representing the number 10 by 2:
  *
  * ```ts

--- a/src/digit-list/first.ts
+++ b/src/digit-list/first.ts
@@ -4,12 +4,9 @@ import { Digit, DigitList, Kind, Type } from "../";
  * `_$first` is a type-level function that returns the first digit of a digit list.
  * If the list is empty, it returns ["0"].
  *
- * ## Parameters
- * 
  * @param T The digit list to extract the first digit from.
  * 
  * @example
- * 
  * ```ts
  * import { $, DigitList, Type } from "hkt-toolbelt";
  *
@@ -27,7 +24,6 @@ export type _$first<T extends DigitList.DigitList> = T extends []
  * It returns the first digit of the digit list. If the list is empty, it returns ["0"].
  *
  * @example
- *
  * For example, we can use `First` to get the first digit of a digit list representing the number 12:
  *
  * ```ts

--- a/src/digit-list/from-string.ts
+++ b/src/digit-list/from-string.ts
@@ -9,13 +9,10 @@ export type _$fromString2<
 
 /**
  * `_$fromString` is a type-level function that converts a string into a digit list and trims leading zeros.
- * 
- * ## Parameters
- * 
+ *
  * @param T - The string to be converted into a digit list.
  *
  * @example
- * 
  * ```ts
  * import { DigitList } from "..";
  *
@@ -28,12 +25,9 @@ export type _$fromString<T extends string> = DigitList._$trim<_$fromString2<T>>;
  * `FromString` is a type-level function that converts a string into a digit list and trims leading zeros.
  * It returns a digit list from a string.
  *
- * ## Parameters
- * 
  * @param A - The string to be converted into a digit list.
  *
  * @example
- *
  * For example, we can use `FromString` to convert a string into a digit list:
  *
  * ```ts
@@ -43,7 +37,6 @@ export type _$fromString<T extends string> = DigitList._$trim<_$fromString2<T>>;
  * ```
  *
  * @example
- * 
  * Also we can use `FromString` to convert a string into a digit list and trim leading zeros.
  *
  * ```ts

--- a/src/digit-list/from-string.ts
+++ b/src/digit-list/from-string.ts
@@ -1,5 +1,4 @@
-import { Kind, Type } from "hkt-toolbelt";
-import { DigitList, Digit } from '..';
+import { Kind, Type, DigitList, Digit } from "..";
 
 export type _$fromString2<
   T extends string,

--- a/src/digit-list/increment.ts
+++ b/src/digit-list/increment.ts
@@ -63,12 +63,9 @@ export type _$increment<
  * `Increment` is a type-level function that increments a digit list.
  * It returns the incremented digit list.
  *
- * ## Parameters
- *
  * @param A - The digit list to increment.
  *
  * @example
- *
  * For example, we can use `Increment` to increment a digit list:
  *
  * ```ts

--- a/src/digit-list/is-even.ts
+++ b/src/digit-list/is-even.ts
@@ -4,13 +4,10 @@ import { Type, Kind, Digit, DigitList } from "..";
  * `_$isEven` is a type-level function that checks if a digit list is even.
  * It returns `true` if the digit list is even, `false` otherwise.
  *
- * ## Parameters
- *
  * @param T - The digit list to check.
  * @param LAST - The last digit of T.
 * 
  * @example
- * 
  * ```ts
  * import { DigitList } from "hkt-toolbelt";
  *
@@ -26,12 +23,9 @@ export type _$isEven<
  * `IsEven` is a type-level function that checks if a digit list is even.
  * It returns `true` if the digit list is even, `false` otherwise.
  *
- * ## Parameters
- *
  * @param T - The digit list to check.
  *
  * @example
- *
  * For example, we can use `IsEven` to check if a digit list is even:
  *
  * ```ts

--- a/src/digit-list/is-odd.ts
+++ b/src/digit-list/is-odd.ts
@@ -3,15 +3,12 @@ import { Type, Kind, Digit, DigitList } from "..";
 /**
  * `_$isOdd` is a type-level function that checks if a digit list is odd.
  *
- * ## Parameters
- *
  * @param T - The digit list to check.
  * @param LAST - The last digit of T.
  *
  * @returns `true` if the digit list is odd, `false` otherwise.
  *
  * @example
- *
  * ```ts
  * import { DigitList} from "hkt-toolbelt";
  *
@@ -27,12 +24,9 @@ export type _$isOdd<
  * `IsOdd` is a type-level function that checks if a digit list is odd.
  * It returns a function that takes a digit list as a parameter and returns `true` if the digit list is odd, `false` otherwise.
  *
- * ## Parameters
- *
  * @param T - The digit list to check.
  *
  * @example
- *
  * For example, we can use `IsOdd` to check if a digit list is odd:
  *
  * ```ts

--- a/src/digit-list/last.ts
+++ b/src/digit-list/last.ts
@@ -4,12 +4,9 @@ import { Type, Kind, Digit, DigitList } from "..";
  * `_$last` is a type-level function that gets the last digit of a digit list.
  * It returns the last digit of the digit list. If the list is empty, it returns "0".
  *
- * ## Parameters
- * 
  * @param A - The digit list to get the last digit from.
  *
  * @example
- * 
  * ```ts
  * import { DigitList } from "hkt-toolbelt";
  *
@@ -26,12 +23,9 @@ export type _$last<T extends DigitList.DigitList> = T extends []
  * `Last` is a type-level function that gets the last digit of a digit list.
  * It returns the last digit of the digit list. If the list is empty, it returns "0".
  *
- * ## Parameters
- * 
  * @param A - The digit list to get the last digit from.
  *
  * @example
- *
  * For example, we can use `Last` to get the last digit of a digit list:
  *
  * ```ts

--- a/src/digit-list/modulo.ts
+++ b/src/digit-list/modulo.ts
@@ -3,14 +3,11 @@ import { Kind, Type, DigitList } from "..";
 /**
  * `_$modulo` is a type-level function that calculates the modulo of two digit lists.
  * Returns the result of the modulo operation.
- * 
- * ## Parameters
- * 
+ *
  * @param A - The first digit list.
  * @param B - The second digit list.
  * 
  * @example
- * 
  * ```ts
  * import { DigitList } from "hkt-toolbelt";
  *
@@ -29,14 +26,11 @@ interface Modulo_T<T extends DigitList.DigitList> extends Kind.Kind {
 /**
  * `Modulo` is a type-level function that calculates the modulo of two digit lists.
  * Returns the result of the modulo operation.
- * 
- * ## Parameters
- * 
+ *
  * @param A - The first digit list.
  * @param B - The second digit list.
  *
  * @example
- *
  * For example, we can use `Modulo` to calculate the modulo of two digit lists:
  *
  * ```ts

--- a/src/digit-list/multiply-digit.ts
+++ b/src/digit-list/multiply-digit.ts
@@ -20,13 +20,10 @@ type _$multiplyDigit2<
  * `_$multiplyDigit` is a type-level function that multiplies a digit list by a single digit.
  * Returns the result of the multiplication operation.
  *
- * ## Parameters
- *
  * @param A - The digit list.
  * @param B - The single digit.
  *
  * @example
- *
  * For example, we can use `_$multiplyDigit` to multiply a digit list by a single digit:
  *
  * ```ts
@@ -53,13 +50,10 @@ export interface MultiplyDigit_T<T extends Digit.Digit> extends Kind.Kind {
  * `MultiplyDigit` is a type-level function that multiplies a digit list by a single digit.
  * Returns the result of the multiplication operation.
  *
- * ## Parameters
- *
  * @param A - The digit list.
  * @param B - The single digit.
  *
  * @example
- *
  * For example, we can use `MultiplyDigit` to multiply a digit list by a single digit:
  *
  * ```ts

--- a/src/digit-list/multiply.ts
+++ b/src/digit-list/multiply.ts
@@ -18,13 +18,10 @@ export type _$multiply2<
  * `_$multiplyDigit` is a type-level function that multiplies a digit list by a single digit.
  * It returns the result of the multiplication operation.
  *
- * ## Parameters
- *
  * @param A - The digit list.
  * @param B - The single digit.
  *
  * @example
- *
  * For example, we can use `_$multiplyDigit` to multiply a digit list by a single digit:
  *
  * ```ts
@@ -49,13 +46,10 @@ export interface Multiply_T<T extends DigitList.DigitList> extends Kind.Kind {
  * `MultiplyDigit` is a type-level function that multiplies a digit list by a single digit.
  * It returns the result of the multiplication operation.
  *
- * ## Parameters
- *
  * @param A - The digit list.
  * @param B - The single digit.
  * 
  * @example
- *
  * For example, we can use `MultiplyDigit` to multiply a digit list by a single digit:
  *
  * ```ts

--- a/src/digit-list/pop.ts
+++ b/src/digit-list/pop.ts
@@ -3,13 +3,10 @@ import { Type, Kind, DigitList } from "..";
 /**
  * `_$pop` is a type-level function that removes the last digit from a digit list.
  * It returns the digit list after the last digit has been removed.
- * 
- * ## Parameters
  *
  * @param A - The digit list.
  *
  * @example
- *
  * For example, we can use `_$pop` to remove the last digit from a digit list:
  *
  * ```ts
@@ -31,12 +28,9 @@ export type _$pop<T extends DigitList.DigitList> = T extends []
  * `Pop` is a type-level function that removes the last digit from a digit list.
  * It returns the digit list after the last digit has been removed.
  *
- * ## Parameters
- *
  * @param A - The digit list.
  * 
  * @example
- *
  * For example, we can use `Pop` to remove the last digit from a digit list:
  *
  * ```ts

--- a/src/digit-list/shift.ts
+++ b/src/digit-list/shift.ts
@@ -4,12 +4,9 @@ import { Type, Kind, DigitList } from "..";
  * `_$shift` is a type-level function that removes the first digit from a digit list.
  * It returns the result of the shift operation.
  *
- * ## Parameters
- *
  * @param T - The digit list.
  *
  * @example
- *
  * For example, we can use `_$shift` to remove the first digit from a digit list:
  *
  * ```ts
@@ -32,7 +29,6 @@ export type _$shift<T extends DigitList.DigitList> = T extends []
  * It returns the result of the shift operation.
  *
  * @example
- *
  * For example, we can use `Shift` to remove the first digit from a digit list:
  *
  * ```ts

--- a/src/digit-list/subtract.ts
+++ b/src/digit-list/subtract.ts
@@ -25,13 +25,10 @@ type _$subtract2<
  * `_$subtract` is a type-level function that subtracts one digit list from another.
  * It returns the result of the subtraction.
  *
- * ## Parameters
- *
  * @param A - A digit list representing a number to substract.
  * @param B - A digit list representing a number to substract by.
  *
  * @example
- *
  * For example, we can use `_$subtract` to subtract one digit list from another:
  *
  * ```ts
@@ -56,13 +53,10 @@ interface Subtract_T<X extends DigitList.DigitList> extends Kind.Kind {
  * `Subtract` is a type-level function that subtracts one digit list from another.
  * It returns the result of the subtraction.
  *
- * ## Parameters
- *
  * @param A - A digit list representing a number to substract.
  * @param B - A digit list representing a number to substract by.
  * 
  * @example
- *
  * For example, we can use `Subtract` to subtract one digit list from another:
  *
  * ```ts

--- a/src/digit-list/to-number.ts
+++ b/src/digit-list/to-number.ts
@@ -4,13 +4,10 @@ import { DigitList, Kind, Number, Type } from "..";
  * `_$toNumber` is a type-level function that converts a digit list to a number.
  * It returns the number from the digit list.
  *
- * ## Parameters
- *
  * @param T - The digit list to convert.
  * @param RESULT - The number that the digit list represents.
  *
  * @example
- *
  * For example, we can use `_$toNumber` to convert a digit list to a number:
  *
  * ```ts
@@ -31,12 +28,9 @@ export type _$toNumber<
  * `ToNumber` is a type-level function that represents a function to convert a digit list to a number.
  * It returns the number from the digit list.
  *
- * ## Parameters
- *
  * @param x - A digit list to convert to a number.
  *
  * @example
- *
  * For example, we can use `ToNumber` to convert a digit list to a number:
  *
  * ```ts

--- a/src/digit-list/to-string.ts
+++ b/src/digit-list/to-string.ts
@@ -11,14 +11,11 @@ type _$toString2<
  * `_$toString` is a type-level function that converts a digit list to a string.
  * It returns the string representation of the digit list.
  *
- * ## Parameters
- *
  * @param T - The digit list to convert.
  * @param JOIN - The string that joins the digits in the list.
  * @param RESULT - The string that the digit list represents.
  *
  * @example
- *
  * For example, we can use `_$toString` to convert a digit list to a string:
  *
  * ```ts
@@ -40,12 +37,9 @@ export type _$toString<
  * `ToString` is a type-level function that converts a digit list to a string.
  * It returns the string representation of the digit list.
  *
- * ## Parameters
- *
  * @param A - A digit list to convert to a string.
  *
  * @example
- *
  * For example, we can use `ToString` to convert a digit list to a string:
  *
  * ```ts

--- a/src/digit-list/trim.ts
+++ b/src/digit-list/trim.ts
@@ -11,14 +11,11 @@ type _$trim2<A extends DigitList.DigitList> = A extends [
  * `_$trim` is a type-level function that trims leading zeros from a digit list.
  * It returns the trimmed digit list.
  *
- * ## Parameters
- *
  * @param A - The digit list to trim.
  * @param TRIM - The digit list after trimming leading zeros.
  * @param OUTPUT - The final output after trimming. If the trimmed list is empty, it returns ["0"].
  *
  * @example
- *
  * For example, we can use `_$trim` to trim leading zeros from a digit list:
  *
  * ```ts
@@ -40,12 +37,9 @@ export type _$trim<
  * `Trim` is a type-level function that trims leading zeros from a digit list.
  * It returns the trimmed digit list.
  *
- * ## Parameters
- *
  * @param x - A digit list to trim leading zeros from.
  *
  * @example
- *
  * For example, we can use `Trim` to trim leading zeros from a digit list:
  *
  * ```ts

--- a/src/digit/add-tens.ts
+++ b/src/digit/add-tens.ts
@@ -23,13 +23,10 @@ type _$addTens_LUT = [
  * the two specified digits.
  * Details can be found in the corresponding lookup-table `_$addTens_LUT`.
  *
- * ## Parameters
- *
  * @param A A one-character decimal digit type.
  * @param B A one-character decimal digit type.
  *
  * @example
- *
  * For example, forwarding two decimal digits `5` and `6` will result in `1`
  * as the added tens digit.
  *
@@ -57,7 +54,6 @@ interface AddTens_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A one-character decimal digit type.
  *
  * @example
- *
  * For example, using the `hkt-toolbelt` `$` type-level applicator,
  * we apply `AddTens` to the digits `5` and `7`:
  *

--- a/src/digit/add.ts
+++ b/src/digit/add.ts
@@ -19,13 +19,10 @@ type _$add_LUT = [
  * does not include any carry-over from the addition (see `_$addTens` for tens 
  * place operation).
  *
- * ## Parameters
- *
  * @param A A one-character decimal digit type.
  * @param B A one-character decimal digit type.
  *
  * @example
- *
  * For example, forwarding two decimal digits `7` and `4` will result in `1`
  * as the result of adding those digits.
  *
@@ -54,7 +51,6 @@ interface Add_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A one-character decimal digit type.
  *
  * @example
- *
  * For example, using the `hkt-toolbelt` `$` type-level applicator,
  * we apply `Add` to the digits `7` and `4`:
  *

--- a/src/digit/compare.ts
+++ b/src/digit/compare.ts
@@ -19,13 +19,10 @@ type _$compare_LUT = [
  * 
  * It returns `1` if A > B, `-1` if A < B and `0` if A === B.
  *
- * ## Parameters
- *
  * @param A A one-character decimal digit type.
  * @param B A one-character decimal digit type.
  *
  * @example
- *
  * For example, forwarding two decimal digits `7` and `4` will result in 1:
  *
  * ```ts
@@ -53,8 +50,7 @@ interface Compare_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A one-character decimal digit type.
  *
  * @example
- *
- * For example, we can use the `$` type-level applicator to apply `Compare` to two digits. 
+ * For example, we can use the `$` type-level applicator to apply `Compare` to two digits.
  * In this example, we compare the digits `7` and `4`.
  *
  * ```ts

--- a/src/digit/decrement-tens.ts
+++ b/src/digit/decrement-tens.ts
@@ -13,12 +13,9 @@ type _$decrementTens_LUT = ["1", "0", "0", "0", "0", "0", "0", "0", "0", "0"];
  * It only operates on individual digits and does not handle the logic
  * for the full subtraction or decrementing of the tens digit.
  *
- * ## Parameters
- *
  * @param A A one-character decimal digit type.
  *
  * @example
- *
  * For example, forwarding a decimal digit `9` will result in:
  *
  * ```ts
@@ -38,7 +35,6 @@ export type _$decrementTens<A extends Digit.Digit> = _$decrementTens_LUT[A];
  * @param A A one-character decimal digit type.
  *
  * @example
- *
  * For example, using the `hkt-toolbelt` `$` type-level applicator,
  * we apply `DecrementTens` to the digit `4`:
  *

--- a/src/digit/decrement.ts
+++ b/src/digit/decrement.ts
@@ -11,10 +11,7 @@ type _$decrement_LUT = ['9', '0', '1', '2', '3', '4', '5', '6', '7', '8']
  *
  * @param A A single-digit type which represents a digit from "0" to "9".
  *
- * ## Example
- *
  * @example
- *
  * For example, if we want to subtract one from the digit "5", we would use
  * this type-level function as follows:
  *
@@ -33,14 +30,9 @@ export type _$decrement<A extends Digit.Digit> = _$decrement_LUT[A]
  *
  * We apply `Decrement` to a digit using the `$` type-level applicator.
  *
- * ## Parameters
- *
  * @param A A single-digit type which represents a digit from "0" to "9".
  *
- * ## Example
- *
  * @example
- *
  * For example, if we want to subtract one from the digit "5", we would use
  * this type-level function as follows:
  *

--- a/src/digit/digit.ts
+++ b/src/digit/digit.ts
@@ -4,10 +4,7 @@
  * literal type. This type is particularly useful when working with
  * type-level numerical operations or string manipulation involving numbers.
  *
- * ## Examples
- *
  * @example
- *
  * Here are some usage examples of the `Digit` type:
  *
  * ```ts
@@ -17,7 +14,6 @@
  * ```
  *
  * @example
- *
  * You can also use the `Digit` type in combination with other `hkt-toolbelt`
  * utilities such as numerical operations or string manipulation.
  *

--- a/src/digit/increment-tens.ts
+++ b/src/digit/increment-tens.ts
@@ -8,14 +8,9 @@ type _$incrementTens_LUT = ['0', '0', '0', '0', '0', '0', '0', '0', '0', '1']
  * is "9", it returns "1", otherwise, it returns "0". The result can be used for
  * incrementing a tens place in a number string.
  *
- * ## Parameters
- *
  * @param A A digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, incrementing a digit "9" will result in the tens place increment
  * of "1":
  *
@@ -39,14 +34,9 @@ export type _$incrementTens<A extends Digit.Digit> = _$incrementTens_LUT[A]
  * `IncrementTens` is a type-level function that takes a digit type `A` as
  * input and returns the tens place increment for that digit.
  *
- * ## Parameters
- *
  * @param A A digit type.
  *
- * ## Example
- *
  * @example
- *
  * We apply `IncrementTens` to a digit using the `$` type-level applicator:
  *
  * ```ts

--- a/src/digit/increment.ts
+++ b/src/digit/increment.ts
@@ -7,14 +7,9 @@ type _$increment_LUT = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
  * returns the next digit in the sequence. If the input digit is "9", the
  * function returns "0".
  *
- * ## Parameters
- *
  * @param A A digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$increment` to increment a digit type:
  *
  * ```ts
@@ -33,7 +28,6 @@ export type _$increment<A extends Digit.Digit> = _$increment_LUT[A]
  * @param A A digit type.
  *
  * @example
- *
  * For example, we can use `Increment` to increment a digit type:
  *
  * We apply `Increment` to a digit type using the `$` type-level applicator:

--- a/src/digit/multiply-tens.ts
+++ b/src/digit/multiply-tens.ts
@@ -5,15 +5,10 @@ import { Type, Kind, Digit } from '..'
  * types, `A` and `B`, and returns the tens place of the product of `A` and `B`.
  * This function works with digit types represented as strings.
  *
- * ## Parameters
- *
  * @param A A single-digit type.
  * @param B A single-digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$multiplyTens` to compute the tens place of the
  * product of two single-digit types:
  *
@@ -53,7 +48,6 @@ interface MultiplyTens_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A single-digit type.
  *
  * @example
- *
  * For example, we can use `MultiplyTens` to compute the tens place of the
  * product of two single-digit types:
  *

--- a/src/digit/multiply.ts
+++ b/src/digit/multiply.ts
@@ -18,15 +18,10 @@ type _$multiply_LUT = [
  * `B`, and returns the result of multiplying `A` by `B`, modulo 10. The result
  * is a single digit type.
  *
- * ## Parameters
- *
  * @param A A digit type.
  * @param B A digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$multiply` to multiply two digit types. In this
  * example, `2` and `3` are passed as type arguments to the type-level function:
  *
@@ -54,7 +49,6 @@ interface Multiply_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A digit type.
  *
  * @example
- *
  * For example, we can use `Multiply` to multiply two digit types. In this
  * example, `2` and `3` are passed as type arguments to the type-level function:
  *

--- a/src/digit/subtract-tens.ts
+++ b/src/digit/subtract-tens.ts
@@ -22,15 +22,10 @@ type _$subtractTens_LUT = [
  * and `B`, and returns the result of subtracting `B` from `A` in the tens
  * place. If `B` is greater than `A`, the result is 1.
  *
- * ## Parameters
- *
  * @param A A digit type.
  * @param B A digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$subtractTens` to subtract two digit types in the
  * tens place:
  *
@@ -62,7 +57,6 @@ interface SubtractTens_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A digit type.
  *
  * @example
- *
  * For example, we can use `SubtractTens` to subtract two digit types in the
  * tens place:
  *

--- a/src/digit/subtract.ts
+++ b/src/digit/subtract.ts
@@ -19,15 +19,10 @@ type _$subtract_LUT = [
  * is performed using a lookup table (`_$subtract_LUT`), which contains the
  * results of all possible digit subtractions.
  *
- * ## Parameters
- *
  * @param A A digit type.
  * @param B A digit type.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `_$subtract` to subtract two digit types. In this
  * example, "2" and "1" are passed as type arguments to the type-level function:
  *
@@ -54,7 +49,6 @@ interface Subtract_T<A extends Digit.Digit> extends Kind.Kind {
  * @param B A digit type.
  *
  * @example
- *
  * For example, we can use `Subtract` to subtract two digit types. In this
  * example, "2" and "1" are passed as type arguments to the type-level function:
  *

--- a/src/digit/zero.ts
+++ b/src/digit/zero.ts
@@ -3,10 +3,7 @@
  * `Digit` type, and can be used in various arithmetic operations and
  * comparisons provided by the `DigitList` and `NaturalNumber` namespaces.
  *
- * ## Example
- *
  * @example
- *
  * For example, we can use `Zero` in arithmetic operations like addition:
  *
  * ```ts

--- a/src/function/constant.spec.ts
+++ b/src/function/constant.spec.ts
@@ -1,4 +1,4 @@
-import { $, Function, Test } from "hkt-toolbelt";
+import { $, Function, Test } from "..";
 
 type Constant_Spec = [
   /**

--- a/src/function/function.spec.ts
+++ b/src/function/function.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, Test } from "..";
 
 type Function_Spec = [
   /**

--- a/src/function/identity.spec.ts
+++ b/src/function/identity.spec.ts
@@ -1,4 +1,4 @@
-import { $, Function, Test } from "hkt-toolbelt";
+import { $, Function, Test } from "..";
 
 type Identity_Spec = [
   /**

--- a/src/function/return-type.spec.ts
+++ b/src/function/return-type.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Function } from "hkt-toolbelt";
+import { $, Test, Function } from "..";
 
 type ReturnType_Spec = [
   /**

--- a/src/kind/composable.spec.ts
+++ b/src/kind/composable.spec.ts
@@ -1,4 +1,4 @@
-import { $, Function, Kind, List, String, Test } from "hkt-toolbelt";
+import { $, Function, Kind, List, String, Test } from "..";
 
 type Composable_Spec = [
   /**

--- a/src/kind/compose.spec.ts
+++ b/src/kind/compose.spec.ts
@@ -1,4 +1,4 @@
-import { $, Function, Kind, List, String, Test } from "hkt-toolbelt";
+import { $, Function, Kind, List, String, Test } from "..";
 
 type Compose_Spec = [
   /**

--- a/src/kind/curry.ts
+++ b/src/kind/curry.ts
@@ -73,7 +73,6 @@ interface Curry_T<N extends number> extends Kind.Kind {
  * See `Combinator.Collate` for a similar combinator.
  *
  * @example
- *
  * ```ts
  * import { $, Kind, Type } from "ts-toolbelt"
  *

--- a/src/kind/pipe.spec.ts
+++ b/src/kind/pipe.spec.ts
@@ -1,4 +1,4 @@
-import { $, Function, Kind, List, String, Test } from "hkt-toolbelt";
+import { $, Function, Kind, List, String, Test } from "..";
 
 type Pipe_Spec = [
   /**

--- a/src/kind/unapply.ts
+++ b/src/kind/unapply.ts
@@ -13,7 +13,6 @@ import { $, Kind, Type, Function } from '..';
  * whereas `Kind._$inputOf` returns the widest category of arguments accepted by the input function.
  * 
  * @example
- *
  * For example, we can use `_$unapply` to determine what argument was passed into an applied type-level function.
  * In this example, we pass in `Add2`, the target function, and `NaturalNumber.Add` into `_$unapply`, 
  * which gives us the input that was passed into `NaturalNumber.Add` to derive `Add2`.
@@ -52,7 +51,6 @@ interface Unapply_T<F extends Kind.Kind> extends Kind.Kind {
  * whereas `Kind._$inputOf` returns the widest category of arguments accepted by the input function.
  *
  * @example
- *
  * For example, we can use `Unapply` to determine what argument was passed into an applied type-level function.
  * In this example, we partially apply `Unapply` to `NaturalNumber.Add`, which results in a
  * type-level function that returns the argument passed into `NaturalNumber.Add` to derive its input, 

--- a/src/list/at.spec.ts
+++ b/src/list/at.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt"
+import { $, List, Test } from "..";
 
 type At_Spec = [
   /**

--- a/src/list/concat.spec.ts
+++ b/src/list/concat.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Concat_Spec = [
   /**

--- a/src/list/concat.ts
+++ b/src/list/concat.ts
@@ -1,21 +1,18 @@
 import { Type, Kind, List } from "..";
 
 /**
- * `_$concat` is a type-level function that concatenates two tuples. 
- * 
- * It takes in two arguments: 
- * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate. 
- * 
- * ## Parameters
- * 
+ * `_$concat` is a type-level function that concatenates two tuples.
+ *
+ * It takes in two arguments:
+ * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate.
+ *
  * @param T A tuple type.
  * @param U A tuple type, or an unknown.
- * * If `U` is not a tuple type, it will be pushed into `T` as its new last element. 
- * 
+ * If `U` is not a tuple type, it will be pushed into `T` as its new last element.
+ *
  * ## Basic Usage
  * 
  * @example
- * 
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  * 
@@ -25,7 +22,6 @@ import { Type, Kind, List } from "..";
  * ## Advanced Usage
  * 
  * @example
- * 
  * Concatenating to a tuple with a rest parameter results in a tuple that contains the concatenated tuple.
  *
  * ```ts
@@ -34,29 +30,29 @@ import { Type, Kind, List } from "..";
  * List._$concat<[1, 2, ...string[]], ["foo"]>; // [1, 2, ...string[], "foo"]
  * ```
  *
- **/
-export type _$concat<U extends unknown, T extends unknown[]> = U extends unknown[] ? [...T, ...U] : List._$push<U, T>
+ */
+export type _$concat<
+  U extends unknown,
+  T extends unknown[]
+> = U extends unknown[] ? [...T, ...U] : List._$push<U, T>;
 
 interface Concat_T<U extends unknown> extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], unknown[]>): _$concat<U, typeof x>;
 }
 
 /**
- * `Concat` is a type-level function that concatenates two tuples. 
- * 
- * It takes in two arguments: 
- * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate. 
- * 
- * ## Parameters
- * 
+ * `Concat` is a type-level function that concatenates two tuples.
+ *
+ * It takes in two arguments:
+ * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate.
+ *
  * @param T A tuple type.
  * @param U A tuple type, or an unknown.
- * * If `U` is not a tuple type, it will be pushed into `T` as its new last element. 
- * 
+ * If `U` is not a tuple type, it will be pushed into `T` as its new last element.
+ *
  * ## Basic Usage
  * 
  * @example
- * 
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  * 
@@ -66,7 +62,6 @@ interface Concat_T<U extends unknown> extends Kind.Kind {
  * ## Advanced Usage
  * 
  * @example
- * 
  * Concatenating to a tuple with a rest parameter results in a tuple that contains the concatenated tuple.
  *
  * ```ts
@@ -75,7 +70,7 @@ interface Concat_T<U extends unknown> extends Kind.Kind {
  * $<$<List.Concat, ["foo"]>, [1, 2, ...string[]]>; // [1, 2, ...string[], "foo"]
  * ```
  *
- **/
+ */
 export interface Concat extends Kind.Kind {
   f(x: this[Kind._]): Concat_T<typeof x>;
 }

--- a/src/list/every.spec.ts
+++ b/src/list/every.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, List, String, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, List, String, Test } from "..";
 
 type Every_Spec = [
   /**

--- a/src/list/filter.spec.ts
+++ b/src/list/filter.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, Kind, List, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, Kind, List, Test } from "..";
 
 type Filter_Spec = [
   /**

--- a/src/list/filter.ts
+++ b/src/list/filter.ts
@@ -13,7 +13,6 @@ import { $, Type, Kind } from "..";
  * @param X A list of types. The target of the filtering operation.
  * 
  * @example
- * 
  * For example, we can use `_$filter` to filter out negative elements from a tuple of numeric types:
  * 
  * ```ts
@@ -51,7 +50,6 @@ interface Filter_T<F extends Kind.Kind<(x: never) => boolean>>
  * @param X A list of types. The target of the filtering operation.
  * 
  * @example
- * 
  * For example, we can define a filter for positive numbers and then apply it to a list:
  * 
  * ```ts
@@ -61,7 +59,6 @@ interface Filter_T<F extends Kind.Kind<(x: never) => boolean>>
  * ```
  * 
  * @example
- * 
  * We can also use the `$N` applicator to invoke `Filter` with a list containing the required arguments
  * This improves readability by allowing us to avoid nesting `$` calls. 
  * 
@@ -75,8 +72,7 @@ interface Filter_T<F extends Kind.Kind<(x: never) => boolean>>
  * ```
  * 
  * @example
- * 
- * By partially applying only the first argument to `Filter`, 
+ * By partially applying only the first argument to `Filter`,
  * we can define a type-level function that can apply the same operation to multiple list inputs.
  * 
  * ```ts
@@ -88,7 +84,6 @@ interface Filter_T<F extends Kind.Kind<(x: never) => boolean>>
  * ```
  * 
  * @example
- * 
  * Another use case for a partially-applied `Filter` function is to implement
  * sophisticated higher-order functionality by passing it into other type-level functions. 
  * 

--- a/src/list/find.spec.ts
+++ b/src/list/find.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, List, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, List, Test } from "..";
 
 type Find_Spec = [
   /**

--- a/src/list/first.spec.ts
+++ b/src/list/first.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type First_Spec = [
   /**

--- a/src/list/flatten-n.ts
+++ b/src/list/flatten-n.ts
@@ -26,7 +26,6 @@ type _$flattenShallow<
  * If N is greater than or equal to the depth of the input tuple `T`, `T` will be flattened completely. 
  * 
  * @example
- * 
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  * 
@@ -40,8 +39,8 @@ type _$flattenShallow<
  *  
  * type Result4 = List._$flattenN<MyList, 5> // [0, 1, 2, 3, 4]
  * ```
- * 
- **/
+ *
+ */
 export type _$flattenN<
   T extends unknown[],
   N extends Number.Number,
@@ -62,22 +61,21 @@ interface FlattenN_T<N extends Number.Number> extends Kind.Kind {
  * If N is greater than or equal to the depth of the input tuple `T`, `T` will be flattened completely. 
  * 
  * @example
-* 
-* ```ts
-* import { $, List } from 'hkt-toolbelt';
-* 
-* type MyList = [0, [1, [2, [3, [4]]]]]
-* 
-* type Result1 = $<$<List.FlattenN, 1>, MyList> // [0, 1, [2, [3, [4]]]]
-*
-* type Result2 = $<$<List.FlattenN, 2>, MyList> // [0, 1, 2, [3, [4]]]
-* 
-* type Result3 = $<$<List.FlattenN, 4>, MyList> // [0, 1, 2, 3, 4]
-*  
-* type Result4 = $<$<List.FlattenN, 5>, MyList> // [0, 1, 2, 3, 4]
-* ```
-* 
-**/
+ * ```ts
+ * import { $, List } from 'hkt-toolbelt';
+ *
+ * type MyList = [0, [1, [2, [3, [4]]]]]
+ *
+ * type Result1 = $<$<List.FlattenN, 1>, MyList> // [0, 1, [2, [3, [4]]]]
+ *
+ * type Result2 = $<$<List.FlattenN, 2>, MyList> // [0, 1, 2, [3, [4]]]
+ *
+ * type Result3 = $<$<List.FlattenN, 4>, MyList> // [0, 1, 2, 3, 4]
+ *
+ * type Result4 = $<$<List.FlattenN, 5>, MyList> // [0, 1, 2, 3, 4]
+ * ```
+ *
+ */
 export interface FlattenN extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], Number.Number>): FlattenN_T<typeof x>;
 }

--- a/src/list/flatten.ts
+++ b/src/list/flatten.ts
@@ -6,16 +6,15 @@ import { Kind, List, Type } from "..";
  * @param T The input tuple.
  * 
  * @example
-* 
-* ```ts
-* import { $, List } from 'hkt-toolbelt';
-* 
-* type MyList = [0, [1, [2, [3, [4]]]]]
-* 
-* type Result = List._$flatten<MyList> // [0, 1, 2, 3, 4]
-* ```
-* 
-**/
+ * ```ts
+ * import { $, List } from 'hkt-toolbelt';
+ *
+ * type MyList = [0, [1, [2, [3, [4]]]]]
+ *
+ * type Result = List._$flatten<MyList> // [0, 1, 2, 3, 4]
+ * ```
+ *
+ */
 export type _$flatten<
   T extends unknown[],
   RESULT extends List.List = T extends [infer H, ...infer R]
@@ -31,16 +30,15 @@ export type _$flatten<
  * @param T The input tuple.
  * 
  * @example
-* 
-* ```ts
-* import { $, List } from 'hkt-toolbelt';
-* 
-* type MyList = [0, [1, [2, [3, [4]]]]]
-* 
-* type Result = $<List.Flatten, MyList> // [0, 1, 2, 3, 4]
-* ```
-* 
-**/
+ * ```ts
+ * import { $, List } from 'hkt-toolbelt';
+ *
+ * type MyList = [0, [1, [2, [3, [4]]]]]
+ *
+ * type Result = $<List.Flatten, MyList> // [0, 1, 2, 3, 4]
+ * ```
+ *
+ */
 export interface Flatten extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], unknown[]>): _$flatten<typeof x>;
 }

--- a/src/list/includes.spec.ts
+++ b/src/list/includes.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, List, String, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, List, String, Test } from "..";
 
 type Includes_Spec = [
   /**

--- a/src/list/is-variadic.spec.ts
+++ b/src/list/is-variadic.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type IsVariadic_Spec = [
   /**

--- a/src/list/iterate.stress.spec.ts
+++ b/src/list/iterate.stress.spec.ts
@@ -1,4 +1,4 @@
-import { $, Kind, NaturalNumber, List, Test } from "hkt-toolbelt";
+import { $, Kind, NaturalNumber, List, Test } from "..";
 
 type Iterate_Stress_Spec = [
   Test.Expect<

--- a/src/list/map.spec.ts
+++ b/src/list/map.spec.ts
@@ -1,4 +1,4 @@
-import { $, $N, $$, Conditional, Function, List, Test } from "hkt-toolbelt";
+import { $, $N, $$, Conditional, Function, List, Test } from "..";
 
 type Map_Spec = [
   /**

--- a/src/list/map.ts
+++ b/src/list/map.ts
@@ -13,7 +13,6 @@ import { $, Type, Kind } from "..";
  * @param X A list of types. The target of the map operation.
  * 
  * @example
- * 
  * For example, we can use `_$map` to extract the same property from a list of objects.
  * 
  * ```ts
@@ -46,7 +45,6 @@ interface Map_T<T extends Kind.Kind> extends Kind.Kind {
  * @param X A list of types. The target of the map operation.
  * 
  * @example
- * 
  * For example, we can use `Map` to extract the same property from a list of objects.
  * 
  * ```ts
@@ -59,7 +57,6 @@ interface Map_T<T extends Kind.Kind> extends Kind.Kind {
  * ]>;  // ["Los Angeles", "Seoul", "Paris"]
  * 
  * @example
- * 
  * We can also use the `$N` applicator to invoke `Map` with a list containing the required arguments
  * This improves readability by allowing us to avoid nesting `$` calls. 
  * 
@@ -77,8 +74,7 @@ interface Map_T<T extends Kind.Kind> extends Kind.Kind {
  * ```
  * 
  * @example
- * 
- * By partially applying only the first argument to `Map`, 
+ * By partially applying only the first argument to `Map`,
  * we can define a type-level function that can apply the same operation to multiple list inputs.
  * 
  * ```ts
@@ -90,7 +86,6 @@ interface Map_T<T extends Kind.Kind> extends Kind.Kind {
  * ```
  * 
  * @example
- * 
  * Another use case for a partially-applied `Map` function is to implement
  * sophisticated higher-order functionality by passing it into other type-level functions. 
  * 

--- a/src/list/pair.spec.ts
+++ b/src/list/pair.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Pair_Spec = [
   /**

--- a/src/list/pop-n.spec.ts
+++ b/src/list/pop-n.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type PopN_Spec = [
   /**

--- a/src/list/push.spec.ts
+++ b/src/list/push.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Push_Spec = [
   /**

--- a/src/list/reduce.ts
+++ b/src/list/reduce.ts
@@ -16,9 +16,8 @@ import { $, Kind, Type, Function } from "..";
  *          To use first element of `X` as the initial argument, simply pass in `Function.Identity`.
  * 
  * @example
- * 
- * For example, we can use `_$reduce` to derive the sum of all elements in a list of numeric types. 
- * 
+ * For example, we can use `_$reduce` to derive the sum of all elements in a list of numeric types.
+ *
  * ```ts
  * import { List } from "hkt-toolbelt";
  * 
@@ -73,9 +72,8 @@ interface Reduce_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * @param X A list of types. The target of the reduce operation.
  * 
  * @example
- * 
- * For example, we can use `Reduce` to derive the sum of all elements in a list of numeric types. 
- * 
+ * For example, we can use `Reduce` to derive the sum of all elements in a list of numeric types.
+ *
  * ```ts
  * import { $, List } from "hkt-toolbelt";
  * 
@@ -83,7 +81,6 @@ interface Reduce_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * ```
  * 
  * @example
- * 
  * We can also use the `$N` applicator to invoke `Reduce` with a list containing the required arguments
  * This improves readability by allowing us to avoid nesting `$` calls three level deep. 
  * 
@@ -98,8 +95,7 @@ interface Reduce_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * ```
  * 
  * @example
- * 
- * By partially applying only the first two arguments to `Reduce`, 
+ * By partially applying only the first two arguments to `Reduce`,
  * we can define a type-level function that can apply the same operation to multiple list inputs.
  * 
  * ```ts
@@ -111,7 +107,6 @@ interface Reduce_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * ```
  * 
  * @example
- * 
  * Another use case for a partially-applied `Reduce` function is to implement
  * sophisticated higher-order functionality by passing it into other type-level functions. 
  * 

--- a/src/list/repeat.ts
+++ b/src/list/repeat.ts
@@ -18,24 +18,21 @@ type _$repeat2<
  * 
  * `_$repeat` can handle an output tuple length of up to 2137, 
  * which is larger than 999, the maximum recursion depth limit of TypeScript.
- * 
- * ## Parameters
- * 
+ *
  * @param T An unknown type.
  * @param N A natural number.
- * * If `N` is not a natural number, returns `never`.
- * 
+ * If `N` is not a natural number, returns `never`.
+ *
  * ## Basic Usage
  * 
  * @example
- * 
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  * 
  * type Result = List._$repeat<"a", 3>; // ["a", "a", "a"]
  * ```
  *
- **/
+ */
 export type _$repeat<
   T extends unknown, 
   N extends Number.Number,

--- a/src/list/reverse.spec.ts
+++ b/src/list/reverse.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Reverse_Spec = [
   /**

--- a/src/list/shift-n.spec.ts
+++ b/src/list/shift-n.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type ShiftN_Spec = [
   /**

--- a/src/list/slice.spec.ts
+++ b/src/list/slice.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Slice_Spec = [
   /**

--- a/src/list/slice.ts
+++ b/src/list/slice.ts
@@ -7,43 +7,40 @@ import { NaturalNumber, Number, DigitList, Digit, Kind, Type, List } from "..";
  * then `START` and `END`, which respectively specify the inclusive start and exclusive end indices of a slice. 
  * Both positive and negative indices are supported, with negative indices being normalized into zero-based indices under the hood. 
  * ´´
- * ## Parameters
- * 
  * @param T A tuple type.
  * @param START An integer type.
  * @param END An integer type.
- * * A negative index counts back from the end of the input tuple. 
- * * If `START < 0`, `START + T["length"]` is used.
- * * If `END < 0`, `END + T["length"]` is used. 
- * 
+ * A negative index counts back from the end of the input tuple.
+ * If `START < 0`, `START + T["length"]` is used.
+ * If `END < 0`, `END + T["length"]` is used.
+ *
  * ## Basic Usage
  *
  * @example
+ * ```ts
+ * import { $, List } from 'hkt-toolbelt';
  *
-* ```ts
-* import { $, List } from 'hkt-toolbelt';
-*
-* type MyList = ['a', 'b', 'c', 'd', 'e'];
-*
-* // Slice the first two elements of `MyList`.
-* type Result1 = List._$slice<MyList, 0, 2>; // ['a', 'b']
-*
-* // Slice the last two elements of `MyList`.
-* type Result2 = List._$slice<MyList, -2, 0>; // ['d', 'e']
-*
-* // Slice the middle three elements of `MyList`.
-* type Result3 = List._$slice<MyList, 1, -1>; // ['b', 'c', 'd']
-* ```
-* 
-* ## Edge Cases
-* 
-* * If `RANGE` is not of length two, or any of its elements is not an integer, returns `never`. 
-* * If `START >= T["length"]`, returns empty tuple.
-* * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
-* * If `END` is greater than or equal to the length of `T`, all elements up to the end are extracted.
-* * If `END` is positioned before or at `START` after normalization, returns empty tuple. 
-* 
-*/
+ * type MyList = ['a', 'b', 'c', 'd', 'e'];
+ *
+ * // Slice the first two elements of `MyList`.
+ * type Result1 = List._$slice<MyList, 0, 2>; // ['a', 'b']
+ *
+ * // Slice the last two elements of `MyList`.
+ * type Result2 = List._$slice<MyList, -2, 0>; // ['d', 'e']
+ *
+ * // Slice the middle three elements of `MyList`.
+ * type Result3 = List._$slice<MyList, 1, -1>; // ['b', 'c', 'd']
+ * ```
+ *
+ * ## Edge Cases
+ *
+ * If `RANGE` is not of length two, or any of its elements is not an integer, returns `never`.
+ * If `START >= T["length"]`, returns empty tuple.
+ * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
+ * If `END` is greater than or equal to the length of `T`, all elements up to the end are extracted.
+ * If `END` is positioned before or at `START` after normalization, returns empty tuple.
+ *
+ */
 type _$slice<
   T extends unknown[], 
   START extends Number.Number,
@@ -78,15 +75,13 @@ interface Slice_T<START extends Number.Number> extends Kind.Kind {
  * `Slice` is a type-level function that extracts and returns a subtuple of specified range from a tuple type. 
  * It takes in three arguments: `START` and `END`, which respectively specify the inclusive start and exclusive end indices of a slice, 
  * and `T`, the tuple that is to be sliced.
- * Both positive and negative indices are supported, with negative indices being normalized into zero-based indices under the hood. 
- * 
- * ## Parameters
- *  
+ * Both positive and negative indices are supported, with negative indices being normalized into zero-based indices under the hood.
+ *
  * @param START An integer type.
  * @param END An integer type.
- * * A negative index counts back from the end of the input tuple. 
- * * If `START < 0`, `START + T["length"]` is used.
- * * If `END < 0`, `END + T["length"]` is used. 
+ * A negative index counts back from the end of the input tuple.
+ * If `START < 0`, `START + T["length"]` is used.
+ * If `END < 0`, `END + T["length"]` is used.
  * @param T A tuple type.
  * 
  * ## Basic Usage
@@ -94,7 +89,6 @@ interface Slice_T<START extends Number.Number> extends Kind.Kind {
  * We apply `Slice` to `START`, `END`, and `T` respectively using the `$` type-level applicator. 
  *
  * @example
- *
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  *
@@ -111,12 +105,12 @@ interface Slice_T<START extends Number.Number> extends Kind.Kind {
  * ```
  * 
  * ## Edge Cases
- * 
- * * If `START` or `END` is not an integer, returns `never`. 
- * * If `START >= T["length"]`, returns empty tuple.
- * * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
- * * If `END` is greater than or equal to the length of `T`, all elements up to the end are extracted.
- * * If `END` is positioned before or at `START` after normalization, returns empty tuple. 
+ *
+ * If `START` or `END` is not an integer, returns `never`.
+ * If `START >= T["length"]`, returns empty tuple.
+ * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
+ * If `END` is greater than or equal to the length of `T`, all elements up to the end are extracted.
+ * If `END` is positioned before or at `START` after normalization, returns empty tuple.
  */
 export interface Slice extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], Number.Number>): Slice_T<typeof x>;

--- a/src/list/some.spec.ts
+++ b/src/list/some.spec.ts
@@ -1,4 +1,4 @@
-import { $, Conditional, Function, List, String, Test } from "hkt-toolbelt";
+import { $, Conditional, Function, List, String, Test } from "..";
 
 type Some_Spec = [
   /**

--- a/src/list/splice.spec.ts
+++ b/src/list/splice.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt";
+import { $, List, Test } from "..";
 
 type Splice_Spec = [
   /**

--- a/src/list/splice.ts
+++ b/src/list/splice.ts
@@ -36,19 +36,16 @@ type _$splice2<
  * 
  * Both positive and negative indices are supported for `START`. Negative indices will be normalized into zero-based indices.
  *
- * ## Parameters
- * 
  * @param T The input tuple.
  * @param START An integer representing the index at which to start splicing.
- * * A negative index counts back from the end of the input tuple. 
- * * If `START < 0`, `START + T["length"]` is used.
+ * A negative index counts back from the end of the input tuple.
+ * If `START < 0`, `START + T["length"]` is used.
  * @param DEL_COUNT A natural number representing the number of elements to remove from T at the starting index.
  * @param INSERTS An array of elements to insert into T at the starting index.
  * 
  * ## Usage
  * 
  * @example
- * 
  * ```ts
  * import { $, List } from 'hkt-toolbelt';
  * 
@@ -62,13 +59,13 @@ type _$splice2<
  * ```
  * 
  * ## Edge Cases
- * 
- * * If `START >= T["length"]`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
- * * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
- * * If `DEL_COUNT`is greater than or equal to the number of elements after the position specified by `START`, then all the elements from `START` to the end of the array will be deleted.
- * * If `START` is not an integer, or `DEL_COUNT` is not a natural number, returns never.
- * 
- **/
+ *
+ * If `START >= T["length"]`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
+ * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
+ * If `DEL_COUNT`is greater than or equal to the number of elements after the position specified by `START`, then all the elements from `START` to the end of the array will be deleted.
+ * If `START` is not an integer, or `DEL_COUNT` is not a natural number, returns never.
+ *
+ */
 export type _$splice<
   T extends List.List,
   START extends Number.Number,
@@ -102,39 +99,36 @@ interface Splice_T<START extends Number.Number> extends Kind.Kind {
  * 
  * Both positive and negative indices are supported for `START`. Negative indices will be normalized into zero-based indices.
  *
- * ## Parameters
- * 
  * @param T The input tuple.
  * @param START An integer representing the index at which to start splicing.
- * * A negative index counts back from the end of the input tuple. 
- * * If `START < 0`, `START + T["length"]` is used.
+ * A negative index counts back from the end of the input tuple.
+ * If `START < 0`, `START + T["length"]` is used.
  * @param DEL_COUNT A natural number representing the number of elements to remove from T at the starting index.
  * @param INSERTS An array of elements to insert into T at the starting index.
  * 
  * ## Usage
  * 
  * @example
-* 
-* ```ts
-* import { $, List } from 'hkt-toolbelt';
-* 
-* type MyList = [0, 1, 2, 3, 4]
-* 
-* type Result1 = $<$<$<$<List.Splice, 1>, 2>, []>, [0, 1, 2, 3, 4]>; // [0, 3, 4]
-*
-* type Result2 = $<<$<$<$<List.Splice, 1>, 2>, ['a', 'b']>, [0, 1, 2, 3, 4]>; // [0, 'a', 'b', 3, 4]
-* 
-* type Result3 = $<$<$<$<List.Splice, -2>, 2>, ['a', 'b']>, [0, 1, 2, 3, 4]>; // [0, 1, 'a', 'b', 4]
-* ```
-* 
-* ## Edge Cases
-* 
-* * If `START >= T["length"]`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
-* * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
-* * If `DEL_COUNT`is greater than or equal to the number of elements after the position specified by `START`, then all the elements from `START` to the end of the array will be deleted.
-* * If `START` is not an integer, or `DEL_COUNT` is not a natural number, returns never.
-* 
-**/
+ * ```ts
+ * import { $, List } from 'hkt-toolbelt';
+ *
+ * type MyList = [0, 1, 2, 3, 4]
+ *
+ * type Result1 = $<$<$<$<List.Splice, 1>, 2>, []>, [0, 1, 2, 3, 4]>; // [0, 3, 4]
+ *
+ * type Result2 = $<<$<$<$<List.Splice, 1>, 2>, ['a', 'b']>, [0, 1, 2, 3, 4]>; // [0, 'a', 'b', 3, 4]
+ *
+ * type Result3 = $<$<$<$<List.Splice, -2>, 2>, ['a', 'b']>, [0, 1, 2, 3, 4]>; // [0, 1, 'a', 'b', 4]
+ * ```
+ *
+ * ## Edge Cases
+ *
+ * If `START >= T["length"]`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
+ * If `START < -T["length"]` or `START` is omitted, `START` is subsituted with 0.
+ * If `DEL_COUNT`is greater than or equal to the number of elements after the position specified by `START`, then all the elements from `START` to the end of the array will be deleted.
+ * If `START` is not an integer, or `DEL_COUNT` is not a natural number, returns never.
+ *
+ */
 export interface Splice extends Kind.Kind {
   f(x: Type._$cast<this[Kind._], Number.Number>): Splice_T<typeof x>;
 }

--- a/src/list/unshift.spec.ts
+++ b/src/list/unshift.spec.ts
@@ -1,4 +1,4 @@
-import { $, List, Test } from "hkt-toolbelt"
+import { $, List, Test } from "..";
 
 type Unshift_Spec = [
   /**

--- a/src/list/zip.ts
+++ b/src/list/zip.ts
@@ -8,14 +8,9 @@ import { $, Kind, List, Number, NaturalNumber } from ".."
  * The zip operation stops when the shortest sub-array is exhausted.
  * Any remaining items in the longer sub-array are ignored, cutting off the result to the length of the shortest sub-array.
  *
- * ## Parameters
- *
  * @param T An array of types.
  *
- * ## Examples
- *
  * @example
- *
  * For example, we can use `_$zip` to perform parallel iteration.
  * In this example, `[[1, 2, 3], ["a", "b", "c"]]` is passed as a type argument to the
  * type-level function:
@@ -27,7 +22,6 @@ import { $, Kind, List, Number, NaturalNumber } from ".."
  * ```
  *
  * @example
- *
  * When an array containing multiple sub-arrays of different lengths are passed into `_$zip`,
  * the length of the returned result will be equal to the shortest sub-array length found in the input array.
  * In this example, `[[1, 2], ["a", "b", "c"], ["A", "B"]]` is passed as a type argument to the
@@ -67,7 +61,6 @@ export type _$zip<
  * @param T An array of arrays.
  *
  * @example
- *
  * For example, we can use `Zip` to perform parallel iteration over multiple sub-arrays.
  * In this example, `Zip` is a type-level function that returns an array of arrays.
  *

--- a/src/natural-number-theory/factorial.spec.ts
+++ b/src/natural-number-theory/factorial.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Number, NaturalNumberTheory } from "hkt-toolbelt";
+import { $, Test, Number, NaturalNumberTheory } from "..";
 
 type Factorial_Spec = [
   /**

--- a/src/natural-number-theory/factorial.stress.spec.ts
+++ b/src/natural-number-theory/factorial.stress.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, NaturalNumberTheory } from "hkt-toolbelt";
+import { $, Test, NaturalNumberTheory } from "..";
 
 type Factorial_Spec = [
   /**

--- a/src/natural-number-theory/fizzbuzz.spec.ts
+++ b/src/natural-number-theory/fizzbuzz.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, NaturalNumberTheory } from "hkt-toolbelt"
+import { $, Test, NaturalNumberTheory } from "..";
 
 type FizzBuzz_Spec = [
   /**

--- a/src/natural-number-theory/fizzbuzz.ts
+++ b/src/natural-number-theory/fizzbuzz.ts
@@ -37,7 +37,6 @@ type DivisibleBy = $N<
  * @param N The number to compute the FizzBuzz result for.
  *
  * @example
- *
  * ```ts
  * import { $, NaturalNumberTheory } from "hkt-toolbelt"
  *
@@ -71,7 +70,6 @@ export type FizzBuzz = $N<
  * @param N The number of FizzBuzz results to compute.
  *
  * @example
- *
  * ```ts
  * import { $, NaturalNumberTheory } from "hkt-toolbelt"
  *

--- a/src/natural-number/compare.ts
+++ b/src/natural-number/compare.ts
@@ -6,16 +6,11 @@ import { Type, Number, Kind, DigitList, NaturalNumber } from "..";
  * The result will be 1 if `A` is greater than `B`, 
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * ## Parameters
- *
  * @param A A natural number type.
  * @param B A natural number type.
  *
- * ## Example
- *
  * @example
- *
- * For example, we can use `_$compare` to compare two natural numbers. 
+ * For example, we can use `_$compare` to compare two natural numbers.
  * In this example, we compare 123 and 321:
  *
  * ```ts
@@ -55,16 +50,11 @@ interface Compare_T<A extends Number.Number> extends Kind.Kind {
  * The result will be 1 if `A` is greater than `B`, 
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * ## Parameters
- *
  * @param A A natural number type.
  * @param B A natural number type.
  *
- * ## Example
- *
  * @example
- *
- * For example, we can use `Compare` to compare two natural numbers. 
+ * For example, we can use `Compare` to compare two natural numbers.
  * In this example, we compare 123 and 321:
  *
  * ```ts

--- a/src/natural-number/is-less-than.spec.ts
+++ b/src/natural-number/is-less-than.spec.ts
@@ -1,4 +1,4 @@
-import { $, NaturalNumber, Test } from "hkt-toolbelt";
+import { $, NaturalNumber, Test } from "..";
 
 type IsLessThan_Spec = [
   /**

--- a/src/natural-number/is-less-than.ts
+++ b/src/natural-number/is-less-than.ts
@@ -8,8 +8,6 @@ import { Number, NaturalNumber, Kind, Type } from "..";
  * This function works by comparing the ordinal values of `A` and `B`. If `B`
  * has a lower ordinal value than `A`, then `B` is less than `A`.
  *
- * ## Parameters
- *
  * @param A The number to compare against.
  * @param B The number to compare.
  */
@@ -39,8 +37,6 @@ interface IsLessThan_T<A extends Number.Number> extends Kind.Kind {
  * types, `A` and `B`, and returns a boolean indicating whether `B` is less
  * than `A`.
  *
- * ## Parameters
- *
  * @param A The number to compare against.
  * @param B The number to evaluate.
  *
@@ -51,7 +47,6 @@ interface IsLessThan_T<A extends Number.Number> extends Kind.Kind {
  * ## Usage Examples
  *
  * @example
- *
  * For example, we can use `IsLessThan` to determine whether a natural number is
  * less than another natural number. In this example, `3` and `2` are passed as
  * type arguments to the type-level function:
@@ -66,7 +61,6 @@ interface IsLessThan_T<A extends Number.Number> extends Kind.Kind {
  * ```
  *
  * @example
- *
  * If we apply `IsLessThan` to `3` and `3`, we should expect to get `false`.
  *
  * ```ts
@@ -76,7 +70,6 @@ interface IsLessThan_T<A extends Number.Number> extends Kind.Kind {
  * ```
  *
  * @example
- *
  * If we apply `IsLessThan` to `3` and `4`, we should also expect to get
  * `false`.
  *

--- a/src/natural-number/modulo-by.ts
+++ b/src/natural-number/modulo-by.ts
@@ -4,8 +4,6 @@ import { NaturalNumber, Type, Number, Kind } from "..";
  * `_$moduloBy` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `B` divided by `A`.
  *
- * ## Parameters
- *
  * @param A The number to divide by to calculate the remainder.
  * @param B The numerator.
  *
@@ -33,8 +31,6 @@ interface ModuloBy_T<A extends number> extends Kind.Kind {
  * `ModuloBy` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `B` divided by `A`.
  *
- * ## Parameters
- *
  * @param A The number to divide by to calculate the remainder.
  * @param B The numerator.
  *
@@ -44,7 +40,6 @@ interface ModuloBy_T<A extends number> extends Kind.Kind {
  * ## Usage Examples
  *
  * @example
- *
  * For example, we can use `ModuloBy` to determine the remainder of a natural
  * number divided by another natural number. In this example, `3` and `4` are
  * passed as type arguments to the type-level function:

--- a/src/natural-number/modulo-by.ts
+++ b/src/natural-number/modulo-by.ts
@@ -1,4 +1,4 @@
-import { NaturalNumber, Type, Number, Kind } from "hkt-toolbelt"
+import { NaturalNumber, Type, Number, Kind } from "..";
 
 /**
  * `_$moduloBy` is a type-level function that takes in two natural number types,

--- a/src/natural-number/modulo.ts
+++ b/src/natural-number/modulo.ts
@@ -4,8 +4,6 @@ import { Type, Number, Kind, DigitList, NaturalNumber } from ".."
  * `Modulo` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `A` divided by `B`.
  *
- * ## Parameters
- *
  * @param A The number to divide.
  * @param B The number to divide by.
  */
@@ -28,15 +26,12 @@ interface Modulo_T<A extends Number.Number> extends Kind.Kind {
  * `Modulo` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `A` divided by `B`.
  *
- * ## Parameters
- *
  * @param A The number to divide.
  * @param B The number to divide by.
  *
  * ## Usage Examples
  *
  * @example
- *
  * For example, we can use `Modulo` to determine the remainder of a natural
  * number divided by another natural number. In this example, `3` and `2` are
  * passed as type arguments to the type-level function:
@@ -51,7 +46,6 @@ interface Modulo_T<A extends Number.Number> extends Kind.Kind {
  * ```
  *
  * @example
- *
  * Here we calculate the remainder of `10` divided by `3`:
  *
  * ```ts

--- a/src/number/absolute.ts
+++ b/src/number/absolute.ts
@@ -5,12 +5,9 @@ import { Number, Type, Kind } from "..";
  * 
  * It returns `T` if T >= 0, and `-T` if T < 0.
  *
- * ## Parameters
- *
  * @param T A number type.
  *
  * @example
- *
  * ```ts
  * import { Number } from "hkt-toolbelt";
  *
@@ -25,19 +22,16 @@ export type _$absolute<T extends Number.Number> = `${T}` extends `-${infer U ext
  * 
  * It returns `T` if T >= 0, and `-T` if T < 0.
  *
- * ## Parameters
- *
  * @param T A number type.
  *
  * @example
+ * ```ts
+ * import { Number } from "hkt-toolbelt";
  *
-* ```ts
-* import { Number } from "hkt-toolbelt";
-*
-* type Result1 = $<Number.Absolute, 42>; // 42
-* type Result2 = $<Number.Absolute, -42>; // 42
-* ```
-*/
+ * type Result1 = $<Number.Absolute, 42>; // 42
+ * type Result2 = $<Number.Absolute, -42>; // 42
+ * ```
+ */
 export interface Absolute extends Kind.Kind {
   f(
     x: Type._$cast<this[Kind._], Number.Number>

--- a/src/number/compare.ts
+++ b/src/number/compare.ts
@@ -59,16 +59,11 @@ export type _$decimalCompare<
  * The result will be 1 if `A` is greater than `B`, 
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * ## Parameters
- *
  * @param A A number type.
  * @param B A number type.
  *
- * ## Example
- *
  * @example
- *
- * For example, we can use `_$compare` to compare two numbers. 
+ * For example, we can use `_$compare` to compare two numbers.
  *
  * ```ts
  * import { Number } from "hkt-toolbelt";
@@ -103,16 +98,11 @@ interface Compare_T<X extends Number.Number> extends Kind.Kind {
  * The result will be 1 if `A` is greater than `B`, 
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * ## Parameters
- *
  * @param A A number type.
  * @param B A number type.
  *
- * ## Example
- *
  * @example
- *
- * For example, we can use `Compare` to compare two numbers. 
+ * For example, we can use `Compare` to compare two numbers.
  *
  * ```ts
  * import { $, Number } from "hkt-toolbelt";

--- a/src/number/from-string.ts
+++ b/src/number/from-string.ts
@@ -1,4 +1,4 @@
-import { Kind, Type } from "hkt-toolbelt";
+import { Kind, Type } from "..";
 
 export type _$fromString<T extends string> = T extends `${infer T extends
   | number

--- a/src/number/negate.ts
+++ b/src/number/negate.ts
@@ -5,12 +5,9 @@ import { Number, Type, Kind, Combinator, Function } from "..";
  * 
  * It returns `-T` if T >= 0, and `T` if T < 0.
  *
- * ## Parameters
- *
  * @param T A number type.
  *
  * @example
- *
  * ```ts
  * import { Number } from "hkt-toolbelt";
  *
@@ -33,19 +30,16 @@ export type _$negate<
  * 
  * It returns `-T` if T >= 0, and `T` if T < 0.
  *
- * ## Parameters
- *
  * @param T A number type.
  *
  * @example
+ * ```ts
+ * import { Number } from "hkt-toolbelt";
  *
-* ```ts
-* import { Number } from "hkt-toolbelt";
-*
-* type Result1 = $<Number.Negate, 42>; // -42
-* type Result2 = $<Number.Negate, -42>; // 42
-* ```
-*/
+ * type Result1 = $<Number.Negate, 42>; // -42
+ * type Result2 = $<Number.Negate, -42>; // 42
+ * ```
+ */
 export interface Negate extends Kind.Kind {
   f(
     x: Type._$cast<this[Kind._], Number.Number>

--- a/src/object/at-path.spec.ts
+++ b/src/object/at-path.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt";
+import { $, Test, Object } from "..";
 
 /**
  * Tests for `Object.AtPath`, which returns the value at a given path in an

--- a/src/object/at.spec.ts
+++ b/src/object/at.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt";
+import { $, Test, Object } from "..";
 
 /**
  * Tests for `Object.At`, which returns the value at a given key in an object.

--- a/src/object/deep-map-values.spec.ts
+++ b/src/object/deep-map-values.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object, String, Function, Conditional } from "hkt-toolbelt";
+import { $, Test, Object, String, Function, Conditional } from "..";
 
 /**
  * Tests for `Object.DeepMap` type, which maps over nested values in an object.

--- a/src/object/keys.spec.ts
+++ b/src/object/keys.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt";
+import { $, Test, Object } from "..";
 
 /**
  * Tests for `Object.Keys` type, which returns the keys as a tuple.

--- a/src/object/map-keys.spec.ts
+++ b/src/object/map-keys.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object, String } from "hkt-toolbelt";
+import { $, Test, Object, String } from "..";
 
 type MapKeys_Spec = [
   /**

--- a/src/object/map-values.spec.ts
+++ b/src/object/map-values.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object, String, Function, Conditional } from "hkt-toolbelt";
+import { $, Test, Object, String, Function, Conditional } from "..";
 
 type MapValues_Spec = [
   /**

--- a/src/object/paths.spec.ts
+++ b/src/object/paths.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt"
+import { $, Test, Object } from "..";
 
 /**
  * Tests for `Object.Paths`, which returns the paths to all values in an object

--- a/src/object/paths.stress.spec.ts
+++ b/src/object/paths.stress.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt"
+import { $, Test, Object } from "..";
 
 type Paths_Spec = [
   /**

--- a/src/object/values.spec.ts
+++ b/src/object/values.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Object } from "hkt-toolbelt";
+import { $, Test, Object } from "..";
 
 /**
  * Tests for `Object.Values` type, which returns the values as a tuple.

--- a/src/string/append.spec.ts
+++ b/src/string/append.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Append_Spec = [
   /**

--- a/src/string/ends-with.spec.ts
+++ b/src/string/ends-with.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type EndsWith_Spec = [
   /**

--- a/src/string/first.spec.ts
+++ b/src/string/first.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for String.First, which extracts the first character type from a

--- a/src/string/includes.spec.ts
+++ b/src/string/includes.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Includes_Spec = [
   /**

--- a/src/string/init.spec.ts
+++ b/src/string/init.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for String.Init, which extracts every element before the last element.

--- a/src/string/is-string.spec.ts
+++ b/src/string/is-string.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for `String.IsString`, which checks if a type is a string.

--- a/src/string/is-template.spec.ts
+++ b/src/string/is-template.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type IsTemplate_Spec = [
   /**

--- a/src/string/join.spec.ts
+++ b/src/string/join.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Join_Spec = [
   /**

--- a/src/string/join.stress.spec.ts
+++ b/src/string/join.stress.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Join_Spec = [
   /**

--- a/src/string/last.spec.ts
+++ b/src/string/last.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for String.Last, which extracts the last character type from a

--- a/src/string/prepend.spec.ts
+++ b/src/string/prepend.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Prepend_Spec = [
   /**

--- a/src/string/replace.spec.ts
+++ b/src/string/replace.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for $<$<String.Replace, From, To> which replaces all instances of From

--- a/src/string/reverse.spec.ts
+++ b/src/string/reverse.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for String.Reverse, which reverses the order of characters in a string.

--- a/src/string/split.spec.ts
+++ b/src/string/split.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type Split_Spec = [
   /**

--- a/src/string/starts-with.spec.ts
+++ b/src/string/starts-with.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 type StartsWith_Spec = [
   /**

--- a/src/string/tail.spec.ts
+++ b/src/string/tail.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for String.Tail, which extracts every element after the first element

--- a/src/string/to-lower.spec.ts
+++ b/src/string/to-lower.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for `String.ToLower`, which converts a string to lowercase for all

--- a/src/string/to-upper.spec.ts
+++ b/src/string/to-upper.spec.ts
@@ -1,4 +1,4 @@
-import { $, String, Test } from "hkt-toolbelt";
+import { $, String, Test } from "..";
 
 /**
  * Tests for `String.ToUpper`, which converts a string to uppercase for all

--- a/src/test/expect-not.spec.ts
+++ b/src/test/expect-not.spec.ts
@@ -1,4 +1,4 @@
-import { Test } from "hkt-toolbelt";
+import { Test } from "..";
 
 type ExpectNot_Spec = [
   /**

--- a/src/test/expect.spec.ts
+++ b/src/test/expect.spec.ts
@@ -1,4 +1,4 @@
-import { Test } from "hkt-toolbelt";
+import { Test } from "..";
 
 type Expect_Spec = [
   /**

--- a/src/type/cast.spec.ts
+++ b/src/type/cast.spec.ts
@@ -1,4 +1,4 @@
-import { Test, Type } from "hkt-toolbelt";
+import { Test, Type } from "..";
 
 type Cast_Spec = [
   /**

--- a/src/type/display.spec.ts
+++ b/src/type/display.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Type } from "hkt-toolbelt";
+import { $, Test, Type } from "..";
 
 /**
  * Tests associated with `Type.Display`, which forces the compiler to resolve

--- a/src/type/infer.ts
+++ b/src/type/infer.ts
@@ -1,4 +1,4 @@
-import { Kind, Type, Function } from "hkt-toolbelt";
+import { Kind, Type, Function } from "..";
 
 type _$inferred =
   | string

--- a/src/type/value-of.spec.ts
+++ b/src/type/value-of.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Type } from "hkt-toolbelt";
+import { $, Test, Type } from "..";
 
 /**
  * Tests associated with `Type.ValueOf`, which extracts the values associated

--- a/src/union/from-list.spec.ts
+++ b/src/union/from-list.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Union } from "hkt-toolbelt"
+import { $, Test, Union } from "..";
 
 /**
  * Test `Union.ToTuple`, which converts a union type to a tuple composed of the

--- a/src/union/to-intersection.spec.ts
+++ b/src/union/to-intersection.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Union } from "hkt-toolbelt";
+import { $, Test, Union } from "..";
 
 declare function overloaded(x: number): string;
 declare function overloaded(x: string): string;

--- a/src/union/to-list.spec.ts
+++ b/src/union/to-list.spec.ts
@@ -1,4 +1,4 @@
-import { $, Test, Union } from "hkt-toolbelt";
+import { $, Test, Union } from "..";
 
 /**
  * Test `Union.ToTuple`, which converts a union type to a tuple composed of the


### PR DESCRIPTION
- Fix all imports from "hkt-toolbelt" to import from local path
- Jsdocs formatting batch changes
  - Remove all instances of `## Parameters`, `## Examples` in jsdocs
  - Remove newlines after `@example` tag