### PR TITLE
Build settings update (fixes stress tests failing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=--max-old-space-size=8192 tsc --project tsconfig.spec.json",
-    "stress": "NODE_OPTIONS=--max-old-space-size=8192 tsc --project tsconfig.stress.json",
+    "stress": "NODE_OPTIONS=--max-old-space-size=24576 tsc --project tsconfig.stress.json",
     "build": "./build.sh",
     "lint-check": "npm run prettier-check && npm run eslint-check",
     "lint": "npm run prettier-fix && npm run eslint-fix",

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "incremental": true,
     // "tsBuildInfoFile": ".tsbuildinfo",
-    "target": "es2016",
+    "target": "es2020",
     "module": "commonjs",
     "paths": {
-      "hkt-toolbelt": ["./src"]
+      "hkt-toolbelt": [
+        "./src"
+      ]
     },
     "rootDir": "./",
     "declaration": true,
@@ -18,6 +20,12 @@
     "forceConsistentCasingInFileNames": false,
     "strict": true
   },
-  "include": ["src/**/*.spec.ts"],
-  "exclude": ["src/**/*.stress.spec.ts", "node_modules", "prompts"]
+  "include": [
+    "src/**/*.spec.ts"
+  ],
+  "exclude": [
+    "src/**/*.stress.spec.ts",
+    "node_modules",
+    "prompts"
+  ]
 }

--- a/tsconfig.stress.json
+++ b/tsconfig.stress.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "incremental": true,
     // "tsBuildInfoFile": ".tsbuildinfo",
-    "target": "es2016",
+    "target": "es2020",
     "module": "commonjs",
     "paths": {
-      "hkt-toolbelt": ["./src"]
+      "hkt-toolbelt": [
+        "./src"
+      ]
     },
     "rootDir": "./",
     "declaration": true,
@@ -18,6 +20,11 @@
     "forceConsistentCasingInFileNames": false,
     "strict": true
   },
-  "include": ["src/**/*.stress.spec.ts"],
-  "exclude": ["node_modules", "prompts"]
+  "include": [
+    "src/**/*.stress.spec.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "prompts"
+  ]
 }


### PR DESCRIPTION
- Increase memory for stress tests to 24gb (fixes "heap out of memory" error)
- Upgrade compilation target for tests to es2020