### PR TITLE
Add hyphen before param description in all JSDocs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
     "plugin:import/warnings",
     "plugin:import/typescript",
     "plugin:prettier/recommended",
-    "plugin:jsdoc/recommended"
+    "plugin:jsdoc/recommended-typescript"
   ],
   "rules": {
     "unused-imports/no-unused-imports": "error",
@@ -49,6 +49,7 @@
     "jsdoc/tag-lines": "off",
     "jsdoc/no-undefined-types": "off",
     "jsdoc/check-types": "off",
+    "jsdoc/require-hyphen-before-param-description": "error",
     "semi": "off",
     "@typescript-eslint/semi": "off",
     "no-unexpected-multiline": "error",

--- a/src/$/$$.ts
+++ b/src/$/$$.ts
@@ -48,8 +48,8 @@ import { Kind, List } from '..'
  * Here, `$$` is being used to pipe `List.Push` and `String.Join` together and
  * then apply them to a list of strings.
  *
- * @param FX A tuple of type-level functions that will be piped together.
- * @param X The input type that the type-level functions will be applied to.
+ * @param FX - A tuple of type-level functions that will be piped together.
+ * @param X - The input type that the type-level functions will be applied to.
  *
  * ### Basic Usage
  *

--- a/src/$/$.ts
+++ b/src/$/$.ts
@@ -30,8 +30,8 @@ import { Kind, Function } from '..'
  * normal generic type parameters. Instead, we would need to use a higher-order
  * type-level function. That is what `hkt-toolbelt` provides.
  *
- * @param F A type-level function.
- * @param X The input type to apply the type-level function to.
+ * @param F - A type-level function.
+ * @param X - The input type to apply the type-level function to.
  *
  * ### Basic Usage
  *

--- a/src/$/$N.ts
+++ b/src/$/$N.ts
@@ -8,8 +8,8 @@ import { Kind } from '..'
  * the contrapositive of `$$`, in that `$$` pipes a value through a list of
  * functions, while `$N` pipes a list of values through a function.
  *
- * @param {Kind.Kind} K The type-level function to apply.
- * @param {List.List} X The list of arguments to apply the type-level function to.
+ * @param {Kind.Kind} K - The type-level function to apply.
+ * @param {List.List} X - The list of arguments to apply the type-level function to.
  *
  * Since all type-level functions are curried, we successively apply the
  * type-level function to each argument in the list.

--- a/src/boolean/and.ts
+++ b/src/boolean/and.ts
@@ -6,8 +6,8 @@ import { Kind, Type } from '..'
  * on `T` and `U`. If both `T` and `U` are true, then `_$and` returns true,
  * otherwise it returns false.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$and` to determine whether two boolean types are
@@ -36,8 +36,8 @@ interface And_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'and' logical operation
  * on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `And` to determine whether two boolean types are

--- a/src/boolean/imply.ts
+++ b/src/boolean/imply.ts
@@ -8,8 +8,8 @@ import { Kind, Type } from '..'
  *
  * This is also known as the 'logical implication' operator.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$imply` to determine whether a statement is true
@@ -40,8 +40,8 @@ interface Imply_T<T extends boolean> extends Kind.Kind {
  *
  * This is also known as the 'logical implication' operator.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Imply` to determine whether a statement is true

--- a/src/boolean/nand.ts
+++ b/src/boolean/nand.ts
@@ -6,8 +6,8 @@ import { Type, Kind } from '..'
  * on `T` and `U`. If both `T` and `U` are true, then `_$nand` returns false,
  * otherwise it returns true.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$nand` to determine whether two boolean types are
@@ -36,8 +36,8 @@ interface Nand_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'nand' logical operation
  * on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Nand` to determine whether two boolean types are

--- a/src/boolean/nimply.ts
+++ b/src/boolean/nimply.ts
@@ -6,8 +6,8 @@ import { Kind, Type } from '..'
  * operation on `T` and `U`. If `T` is true and `U` is false, then `_$nimply`
  * returns true, otherwise it returns false.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$nimply` to determine whether two boolean types
@@ -36,8 +36,8 @@ interface Nimply_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'not-implies' logical
  * operation on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Nimply` to determine whether two boolean types

--- a/src/boolean/nor.ts
+++ b/src/boolean/nor.ts
@@ -6,8 +6,8 @@ import { Type, Kind } from '..'
  * on `T` and `U`. If both `T` and `U` are false, then `_$nor` returns true,
  * otherwise it returns false.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$nor` to determine whether two boolean types are
@@ -36,8 +36,8 @@ interface Nor_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'nor' logical operation
  * on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Nor` to determine whether two boolean types are both

--- a/src/boolean/not.ts
+++ b/src/boolean/not.ts
@@ -5,7 +5,7 @@ import { Type, Kind } from '..'
  * returns the boolean result of applying the 'not' logical operation on `T`.
  * If `T` is true, then `_$not` returns false, otherwise it returns true.
  *
- * @param T A boolean type.
+ * @param T - A boolean type.
  *
  * @example
  * For example, we can use `_$not` to negate a boolean type:
@@ -22,7 +22,7 @@ export type _$not<T extends boolean> = T extends true ? false : true
  * `Not` is a type-level function that takes in a boolean type `T`, and
  * returns the boolean result of applying the 'not' logical operation on `T`.
  *
- * @param T A boolean type.
+ * @param T - A boolean type.
  *
  * @example
  * For example, we can use `Not` to negate a boolean type:

--- a/src/boolean/or.ts
+++ b/src/boolean/or.ts
@@ -6,8 +6,8 @@ import { Type, Kind } from '..'
  * on `T` and `U`. If either `T` or `U` is true, then `_$or` returns true,
  * otherwise it returns false.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$or` to determine whether at least one of two boolean
@@ -36,8 +36,8 @@ interface Or_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'or' logical operation
  * on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Or` to determine whether at least one of two boolean

--- a/src/boolean/xnor.ts
+++ b/src/boolean/xnor.ts
@@ -6,8 +6,8 @@ import { Type, Kind } from '..'
  * on `T` and `U`. If `T` and `U` are equal, then `_$xnor` returns true,
  * otherwise it returns false.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$xnor` to determine whether two boolean types are
@@ -43,8 +43,8 @@ interface Xnor_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'xnor' logical operation
  * on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Xnor` to determine whether two boolean types are

--- a/src/boolean/xor.ts
+++ b/src/boolean/xor.ts
@@ -6,8 +6,8 @@ import { Type, Kind } from '..'
  * logical operation on `T` and `U`. If `T` and `U` are the same, then
  * `_$xor` returns false, otherwise it returns true.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `_$xor` to determine whether two boolean types are
@@ -33,8 +33,8 @@ interface Xor_T<T extends boolean> extends Kind.Kind {
  * `U`, and returns the boolean result of applying the 'exclusive or' (xor)
  * logical operation on `T` and `U`.
  *
- * @param T A boolean type.
- * @param U A boolean type.
+ * @param T - A boolean type.
+ * @param U - A boolean type.
  *
  * @example
  * For example, we can use `Xor` to determine whether two boolean types are

--- a/src/combinator/apply-self.ts
+++ b/src/combinator/apply-self.ts
@@ -11,7 +11,7 @@ import { $, Type, Kind, Combinator } from '..'
  * where the function `f` takes in itself as an argument, and returns its own
  * application to itself.
  *
- * @param F A recursive kind that takes in itself as a type argument.
+ * @param F - A recursive kind that takes in itself as a type argument.
  *
  * @example
  * For example, we can use `ApplySelf` to create the omega combinator, which

--- a/src/combinator/collate.ts
+++ b/src/combinator/collate.ts
@@ -43,7 +43,7 @@ export type _$collate<N extends number> = N extends 0 ? [] : _$collate2<N>
  * applications will return a tuple of length `N`, containing the arguments
  * applied.
  *
- * @param N The arity of the type-level function to create.
+ * @param N - The arity of the type-level function to create.
  *
  * This is useful for creating type-level functions that are 'variadic' in the
  * sense that they can take in a specified number of arguments.

--- a/src/conditional/equals-all.ts
+++ b/src/conditional/equals-all.ts
@@ -4,8 +4,8 @@ import { Type, Kind, List, Conditional } from '..'
  * `_$equalsAll` is a type-level function that takes in an array of types `T`,
  * and returns `true` if all elements of `T` are equal or `T` is empty.
  *
- * @param T An array of types.
- * @param U A type.
+ * @param T - An array of types.
+ * @param U - A type.
  *
  * @example
  * For example, we can use `_$equalsAll` to determine whether a series of types are equal.
@@ -62,7 +62,7 @@ export type _$equalsAll<T extends List.List, PREV = T[0]> = T extends [
  * type-level function that returns `true` if all elements of `T` evaluate to the same type or `T` is empty,
  * and `false` if otherwise.
  *
- * @param T An array of types.
+ * @param T - An array of types.
  *
  * @example
  * For example, we can use `EqualsAll` to determine whether multiple types are equal.

--- a/src/conditional/equals.ts
+++ b/src/conditional/equals.ts
@@ -4,8 +4,8 @@ import { Kind } from '..'
  * `_$equals` is a type-level function that takes in two types, `T` and `U`, and
  * returns `true` if `T` and `U` are the same type, and `false` otherwise.
  *
- * @param T A type.
- * @param U A type.
+ * @param T - A type.
+ * @param U - A type.
  *
  * @example
  * For example, we can use `_$equals` to determine whether two types are equal.
@@ -39,8 +39,8 @@ interface Equals_T<T> extends Kind.Kind {
  * type-level function that takes in one type, `U`, and returns `true` if `U` is
  * the same type as `T`, and `false` otherwise.
  *
- * @param T A type.
- * @param U A type.
+ * @param T - A type.
+ * @param U - A type.
  *
  * @example
  * For example, we can use `Equals` to determine whether two types are equal.

--- a/src/conditional/extends-all.ts
+++ b/src/conditional/extends-all.ts
@@ -5,8 +5,8 @@ import { Type, Kind, List, Conditional } from '..'
  * and returns `true` if and only if all elements of `T` extend `U`, or `T` is empty.
  * Otherwise it returns `false`.
  *
- * @param T An array of types.
- * @param U A type.
+ * @param T - An array of types.
+ * @param U - A type.
  *
  * @example
  * For example, we can use `_$extendsAll` to determine whether a series of type expressions all extend a second input type.
@@ -68,8 +68,8 @@ interface ExtendsAll_T<U extends unknown> extends Kind.Kind {
  *
  * If T is empty, `true` is returned.
  *
- * @param U A type.
- * @param T An array of types.
+ * @param U - A type.
+ * @param T - An array of types.
  *
  * @example
  * For example, we can use `ExtendsAll` to determine whether a series of types all extend a second input type.

--- a/src/conditional/extends.ts
+++ b/src/conditional/extends.ts
@@ -11,8 +11,8 @@ import { Kind } from '..'
  * ensures that we are only checking if `X` is a subtype of `T`, rather than
  * checking if `T` is a subtype of `X`.
  *
- * @param T The supertype that we are checking if `X` extends.
- * @param X The type that we are checking if it is a subtype of `T`.
+ * @param T - The supertype that we are checking if `X` extends.
+ * @param X - The type that we are checking if it is a subtype of `T`.
  *
  * @example
  * For example, we can use `_$extends` to determine whether a type is a subtype
@@ -39,8 +39,8 @@ interface Extends_T<T> extends Kind.Kind {
  * `Extends` is a type-level function that takes in two types, `T` and `U`, and
  * returns a boolean that represents whether `T` extends `U`.
  *
- * @param T The supertype that we are checking if `U` extends.
- * @param U The type that we are checking if it is a subtype of `T`.
+ * @param T - The supertype that we are checking if `U` extends.
+ * @param U - The type that we are checking if it is a subtype of `T`.
  *
  * @example
  * For example, we can use `Extends` to determine whether a type `T` extends a

--- a/src/conditional/if.ts
+++ b/src/conditional/if.ts
@@ -8,10 +8,10 @@ import { $, Type, Kind } from '..'
  *
  * This can be thought of as a type-level ternary operator.
  *
- * @param Predicate A type-level function of the form `(x: never) => boolean`.
- * @param Then A type-level function that is applied on the truthy branch.
- * @param Else A type-level function that is applied on the falsy branch.
- * @param X The input to the predicate function.
+ * @param Predicate - A type-level function of the form `(x: never) => boolean`.
+ * @param Then - A type-level function that is applied on the truthy branch.
+ * @param Else - A type-level function that is applied on the falsy branch.
+ * @param X - The input to the predicate function.
  */
 export type _$if<
   Predicate extends Kind.Kind<(x: never) => boolean>,
@@ -54,12 +54,12 @@ interface If_T1<Predicate extends Kind.Kind<(x: never) => boolean>>
  *
  * This can be thought of as a type-level ternary operator.
  *
- * @param Predicate A type-level function of the form `(x: never) => boolean`.
- * @param Then A type-level function that is applied when the predicate returns
+ * @param Predicate - A type-level function of the form `(x: never) => boolean`.
+ * @param Then - A type-level function that is applied when the predicate returns
  * `true`.
- * @param Else A type-level function that is applied when the predicate returns
+ * @param Else - A type-level function that is applied when the predicate returns
  * `false`.
- * @param X The input to the predicate function.
+ * @param X - The input to the predicate function.
  *
  * ## Usage Examples
  *

--- a/src/conditional/is-supertype-of.ts
+++ b/src/conditional/is-supertype-of.ts
@@ -12,8 +12,8 @@ import { $, $$, Conditional, Kind } from '..'
  * This is useful if it is known that `T` extends `X`,
  * but the two arguments are being supplied in the opposite order expected by `_$extends`.
  *
- * @param T The subtype that we are checking if `X` is a supertype of.
- * @param X The type that we are checking if it is a supertype of `T`.
+ * @param T - The subtype that we are checking if `X` is a supertype of.
+ * @param X - The type that we are checking if it is a supertype of `T`.
  *
  * @example
  * For example, we can use `_$isSupertypeOf` to determine whether a type is a supertype
@@ -48,8 +48,8 @@ interface IsSupertypeOf_T<T> extends Kind.Kind {
  * This is useful if it is known that `U` extends `T`,
  * but the two arguments are being supplied in the opposite order expected by `Extends`.
  *
- * @param T The supertype that we are checking if `U` extends.
- * @param U The type that we are checking if it is a subtype of `T`.
+ * @param T - The supertype that we are checking if `U` extends.
+ * @param U - The type that we are checking if it is a subtype of `T`.
  *
  * @example
  * For example, we can use `IsSupertypeOf` to determine whether a given type `T` is a supertype of

--- a/src/conditional/not-equals.ts
+++ b/src/conditional/not-equals.ts
@@ -4,8 +4,8 @@ import { Kind } from '..'
  * `_$notEquals` is a type-level function that returns `true` if `T` and `U` are
  * not equal. Otherwise, it returns `false`.
  *
- * @param T The first type to compare.
- * @param U The second type to compare.
+ * @param T - The first type to compare.
+ * @param U - The second type to compare.
  *
  * @example
  * In this example, `true` and `false` are passed as type arguments to the
@@ -27,8 +27,8 @@ interface NotEquals_T<T> extends Kind.Kind {
  * `NotEquals` is a type-level function that returns `true` if `T` and `U` are
  * not equal. Otherwise, it returns `false`.
  *
- * @param T The first type to compare.
- * @param U The second type to compare.
+ * @param T - The first type to compare.
+ * @param U - The second type to compare.
  *
  * @example
  * ```ts

--- a/src/digit-list/add.ts
+++ b/src/digit-list/add.ts
@@ -106,8 +106,8 @@ type _$add2<
  * `_$add` is a type-level function that takes in two digit lists `A` and `B`,
  * and returns the sum of the two digit lists as a new digit list.
  *
- * @param A A digit list.
- * @param B A digit list.
+ * @param A - A digit list.
+ * @param B - A digit list.
  *
  * @example
  * For example, we can use `_$add` to add two digit lists representing the
@@ -135,8 +135,8 @@ interface Add_T<X extends DigitList.DigitList> extends Kind.Kind {
  * `Add` is a type-level function that takes in two digit lists `A` and `B`,
  * and returns the sum of the two digit lists as a new digit list.
  *
- * @param A A digit list.
- * @param B A digit list.
+ * @param A - A digit list.
+ * @param B - A digit list.
  *
  * @example
  * For example, we can use `Add` to add two digit lists representing the

--- a/src/digit-list/compare.ts
+++ b/src/digit-list/compare.ts
@@ -101,8 +101,8 @@ type _$compare2<
  * 1 if `A` is greater than `B`, 0 if `A` is equal to `B`, and -1 if `A` is
  * less than `B`.
  *
- * @param A A digit list type.
- * @param B A digit list type.
+ * @param A - A digit list type.
+ * @param B - A digit list type.
  *
  * @example
  * For example, we can use `_$compare` to compare two digit lists. In this
@@ -139,8 +139,8 @@ interface Compare_T<X extends DigitList.DigitList> extends Kind.Kind {
  * 1 if `A` is greater than `B`, 0 if `A` is equal to `B`, and -1 if `A` is
  * less than `B`.
  *
- * @param A A digit list type.
- * @param B A digit list type.
+ * @param A - A digit list type.
+ * @param B - A digit list type.
  *
  * @example
  *

--- a/src/digit-list/decrement.ts
+++ b/src/digit-list/decrement.ts
@@ -87,7 +87,7 @@ type _$decrement2<
  * digit list by 1. If the input digit list is empty or represents zero, the
  * result will be a digit list representing zero.
  *
- * @param A A digit list type.
+ * @param A - A digit list type.
  *
  * @example
  * For example, we can use `_$decrement` to decrement a digit list representing
@@ -122,7 +122,7 @@ export type _$decrement<A extends DigitList.DigitList> = DigitList._$trim<
  * digit list by 1. If the input digit list is empty or represents zero, the
  * result will be a digit list representing zero.
  *
- * @param A A digit list type.
+ * @param A - A digit list type.
  *
  * @example
  * For example, we can use `Decrement` to decrement a digit list representing

--- a/src/digit-list/divide-by-subtraction.ts
+++ b/src/digit-list/divide-by-subtraction.ts
@@ -87,9 +87,9 @@ type _$divideBySubtraction2<
  * It takes in two digit lists `A` and `B` representing the dividend and divisor respectively, and an operation type
  * which can be either "DIVIDE" or "MODULO". It returns the result of the operation (division or substraction).
  *
- * @param A A digit list representing a number to divide.
- * @param B A digit list representing a number to divide by.
- * @param OPERATION A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
+ * @param A - A digit list representing a number to divide.
+ * @param B - A digit list representing a number to divide by.
+ * @param OPERATION - A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
  *
  * @example
  * For example, we can use `_$divideBySubtraction` to divide a digit list representing the number 10 by 2:
@@ -132,8 +132,8 @@ interface DivideBySubtraction_T<A extends DigitList.DigitList>
  * `DivideBySubtraction` is a type-level function that performs a division by subtraction.
  * It returns the result of the division.
  *
- * @param A A digit list representing a number to divide.
- * @param B A digit list representing a number to divide by.
+ * @param A - A digit list representing a number to divide.
+ * @param B - A digit list representing a number to divide by.
  *
  * @example
  * For example, we can use `DivideBySubtraction` to divide a digit list representing the number 10 by 2:

--- a/src/digit-list/divide.ts
+++ b/src/digit-list/divide.ts
@@ -92,9 +92,9 @@ type _$divide2<
  * which can be either "DIVIDE" or "MODULO". It checks if the divisor is 0 or 1 and returns the appropriate result.
  * If the divisor is neither 0 nor 1, it calls the `_$divide2` function to perform the division.
  *
- * @param A A digit list representing a number to divide.
- * @param B A digit list representing a number to divide by.
- * @param OPERATION A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
+ * @param A - A digit list representing a number to divide.
+ * @param B - A digit list representing a number to divide by.
+ * @param OPERATION - A string type representing the operation to be performed. Can be either "DIVIDE" or "MODULO".
  *
  * @example
  * For example, we can use `_$divide` to divide a digit list representing the number 10 by 2:

--- a/src/digit-list/first.ts
+++ b/src/digit-list/first.ts
@@ -4,7 +4,7 @@ import { Digit, DigitList, Kind, Type } from '../'
  * `_$first` is a type-level function that returns the first digit of a digit list.
  * If the list is empty, it returns ["0"].
  *
- * @param T The digit list to extract the first digit from.
+ * @param T - The digit list to extract the first digit from.
  *
  * @example
  * ```ts

--- a/src/digit/add-tens.ts
+++ b/src/digit/add-tens.ts
@@ -23,8 +23,8 @@ type _$addTens_LUT = [
  * the two specified digits.
  * Details can be found in the corresponding lookup-table `_$addTens_LUT`.
  *
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  * For example, forwarding two decimal digits `5` and `6` will result in `1`
@@ -50,8 +50,8 @@ interface AddTens_T<A extends Digit.Digit> extends Kind.Kind {
  * `A` and `B`, adds them together, and returns the resultant tens digit.
  *
  * ## Parameters
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  * For example, using the `hkt-toolbelt` `$` type-level applicator,

--- a/src/digit/add.ts
+++ b/src/digit/add.ts
@@ -23,8 +23,8 @@ type _$add_LUT = [
  * does not include any carry-over from the addition (see `_$addTens` for tens
  * place operation).
  *
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  * For example, forwarding two decimal digits `7` and `4` will result in `1`
@@ -51,8 +51,8 @@ interface Add_T<A extends Digit.Digit> extends Kind.Kind {
  * the resulting digit type.
  *
  * ## Parameters
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  * For example, using the `hkt-toolbelt` `$` type-level applicator,

--- a/src/digit/compare.ts
+++ b/src/digit/compare.ts
@@ -27,8 +27,8 @@ type _$compare_LUT = [
  *
  * It returns `1` if A > B, `-1` if A < B and `0` if A === B.
  *
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  * For example, forwarding two decimal digits `7` and `4` will result in 1:
@@ -55,8 +55,8 @@ interface Compare_T<A extends Digit.Digit> extends Kind.Kind {
  * {-1, 0, or 1}.
  *
  * ## Parameters
- * @param A A one-character decimal digit type.
- * @param B A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
+ * @param B - A one-character decimal digit type.
  *
  * @example
  *

--- a/src/digit/decrement-tens.ts
+++ b/src/digit/decrement-tens.ts
@@ -20,7 +20,7 @@ type _$decrementTens_LUT = ['1', '0', '0', '0', '0', '0', '0', '0', '0', '0']
  * It only operates on individual digits and does not handle the logic
  * for the full subtraction or decrementing of the tens digit.
  *
- * @param A A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
  *
  * @example
  * For example, forwarding a decimal digit `9` will result in:
@@ -39,7 +39,7 @@ export type _$decrementTens<A extends Digit.Digit> = _$decrementTens_LUT[A]
  * during a subtraction operation.
  *
  * ## Parameters
- * @param A A one-character decimal digit type.
+ * @param A - A one-character decimal digit type.
  *
  * @example
  *

--- a/src/digit/decrement.ts
+++ b/src/digit/decrement.ts
@@ -14,7 +14,7 @@ type _$decrement_LUT = ['9', '0', '1', '2', '3', '4', '5', '6', '7', '8']
  *
  * ## Parameter
  *
- * @param A A single-digit type which represents a digit from "0" to "9".
+ * @param A - A single-digit type which represents a digit from "0" to "9".
  *
  * @example
  * For example, if we want to subtract one from the digit "5", we would use
@@ -35,7 +35,7 @@ export type _$decrement<A extends Digit.Digit> = _$decrement_LUT[A]
  *
  * We apply `Decrement` to a digit using the `$` type-level applicator.
  *
- * @param A A single-digit type which represents a digit from "0" to "9".
+ * @param A - A single-digit type which represents a digit from "0" to "9".
  *
  * @example
  * For example, if we want to subtract one from the digit "5", we would use

--- a/src/digit/increment-tens.ts
+++ b/src/digit/increment-tens.ts
@@ -13,7 +13,7 @@ type _$incrementTens_LUT = ['0', '0', '0', '0', '0', '0', '0', '0', '0', '1']
  * is "9", it returns "1", otherwise, it returns "0". The result can be used for
  * incrementing a tens place in a number string.
  *
- * @param A A digit type.
+ * @param A - A digit type.
  *
  * @example
  * For example, incrementing a digit "9" will result in the tens place increment
@@ -39,7 +39,7 @@ export type _$incrementTens<A extends Digit.Digit> = _$incrementTens_LUT[A]
  * `IncrementTens` is a type-level function that takes a digit type `A` as
  * input and returns the tens place increment for that digit.
  *
- * @param A A digit type.
+ * @param A - A digit type.
  *
  * @example
  * We apply `IncrementTens` to a digit using the `$` type-level applicator:

--- a/src/digit/increment.ts
+++ b/src/digit/increment.ts
@@ -11,7 +11,7 @@ type _$increment_LUT = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
  * returns the next digit in the sequence. If the input digit is "9", the
  * function returns "0".
  *
- * @param A A digit type.
+ * @param A - A digit type.
  *
  * @example
  * For example, we can use `_$increment` to increment a digit type:
@@ -29,7 +29,7 @@ export type _$increment<A extends Digit.Digit> = _$increment_LUT[A]
  * returns the next digit in the sequence. If the input digit is "9", the
  * function returns "0".
  *
- * @param A A digit type.
+ * @param A - A digit type.
  *
  * @example
  * For example, we can use `Increment` to increment a digit type:

--- a/src/digit/multiply-tens.ts
+++ b/src/digit/multiply-tens.ts
@@ -5,8 +5,8 @@ import { Type, Kind, Digit } from '..'
  * types, `A` and `B`, and returns the tens place of the product of `A` and `B`.
  * This function works with digit types represented as strings.
  *
- * @param A A single-digit type.
- * @param B A single-digit type.
+ * @param A - A single-digit type.
+ * @param B - A single-digit type.
  *
  * @example
  * For example, we can use `_$multiplyTens` to compute the tens place of the
@@ -59,8 +59,8 @@ interface MultiplyTens_T<A extends Digit.Digit> extends Kind.Kind {
  * `MultiplyTens` is a type-level function that takes in two single-digit
  * types, `A` and `B`, and returns the tens place of the product of `A` and `B`.
  *
- * @param A A single-digit type.
- * @param B A single-digit type.
+ * @param A - A single-digit type.
+ * @param B - A single-digit type.
  *
  * @example
  * For example, we can use `MultiplyTens` to compute the tens place of the

--- a/src/digit/multiply.ts
+++ b/src/digit/multiply.ts
@@ -26,8 +26,8 @@ type _$multiply_LUT = [
  * `B`, and returns the result of multiplying `A` by `B`, modulo 10. The result
  * is a single digit type.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `_$multiply` to multiply two digit types. In this
@@ -53,8 +53,8 @@ interface Multiply_T<A extends Digit.Digit> extends Kind.Kind {
  * `B`, and returns the result of multiplying `A` by `B`, modulo 10. The result
  * is a single digit type.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `Multiply` to multiply two digit types. In this

--- a/src/digit/subtract-tens.ts
+++ b/src/digit/subtract-tens.ts
@@ -22,8 +22,8 @@ type _$subtractTens_LUT = [
  * and `B`, and returns the result of subtracting `B` from `A` in the tens
  * place. If `B` is greater than `A`, the result is 1.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `_$subtractTens` to subtract two digit types in the
@@ -53,8 +53,8 @@ interface SubtractTens_T<A extends Digit.Digit> extends Kind.Kind {
  * and `B`, and returns the result of subtracting `B` from `A` in the tens
  * place. If `B` is greater than `A`, the result is 1.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `SubtractTens` to subtract two digit types in the

--- a/src/digit/subtract.ts
+++ b/src/digit/subtract.ts
@@ -28,8 +28,8 @@ type _$subtract_LUT = [
  * subtraction is performed using a lookup table (`_$subtract_LUT`), which
  * contains the results of all possible digit subtractions.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `_$subtract` to subtract two digit types. In this
@@ -54,8 +54,8 @@ interface Subtract_T<A extends Digit.Digit> extends Kind.Kind {
  * `Subtract` is a type-level function that takes in two digit types, `A` and
  * `B`, and returns the digit result of subtracting `B` from `A`.
  *
- * @param A A digit type.
- * @param B A digit type.
+ * @param A - A digit type.
+ * @param B - A digit type.
  *
  * @example
  * For example, we can use `Subtract` to subtract two digit types. In this

--- a/src/kind/compose.ts
+++ b/src/kind/compose.ts
@@ -7,8 +7,8 @@ import { $, Type, List, Kind } from '..'
  * right to left, and applies the resulting type-level function to the second
  * input type.
  *
- * @param {Kind.Kind[]} FX a tuple of type-level functions
- * @param X a type to which a `Kind` can be applied.
+ * @param {Kind.Kind[]} FX - a tuple of type-level functions
+ * @param X - a type to which a `Kind` can be applied.
  *
  * @see {@link Kind._$pipe}
  * `Kind._$pipe` provides the same functionality as `_$compose` but evaluates the list of functions in reverse order.
@@ -56,8 +56,8 @@ interface Compose_T<FX extends Kind.Kind[]> extends Kind.Kind {
  * composes the functions in its input list from right to left,
  * and returns a higher-kinded-type function that takes in a type and returns the result of the composition.
  *
- * @param {Kind.Kind[]} FX  a tuple of type-level functions
- * @param X a type to which a `Kind` can be applied.
+ * @param {Kind.Kind[]} FX  - a tuple of type-level functions
+ * @param X - a type to which a `Kind` can be applied.
  *
  * @see {@link Kind.Pipe}
  * `Kind.Pipe` provides the same functionality as `Compose` but evaluates the list of functions in reverse order.

--- a/src/kind/curry.ts
+++ b/src/kind/curry.ts
@@ -12,8 +12,8 @@ import { $, Kind, Number, NaturalNumber, Conditional, Type } from '..'
  * argument is applied. Once the tuple has `N` elements, it applies the
  * type-level function `K` to the tuple.
  *
- * @param {Number.Number} N The number of arguments to expect.
- * @param {Kind.Kind} K The type-level function to curry.
+ * @param {Number.Number} N - The number of arguments to expect.
+ * @param {Kind.Kind} K - The type-level function to curry.
  *
  * See `Combinator.Collate` for a similar combinator.
  */
@@ -67,8 +67,8 @@ interface Curry_T<N extends number> extends Kind.Kind {
  * argument is applied. Once the tuple has `N` elements, it applies the
  * type-level function `K` to the tuple.
  *
- * @param {Number.Number} N The number of arguments to expect.
- * @param {Kind.Kind} K The type-level function to curry.
+ * @param {Number.Number} N - The number of arguments to expect.
+ * @param {Kind.Kind} K - The type-level function to curry.
  *
  * See `Combinator.Collate` for a similar combinator.
  *

--- a/src/kind/pipe.ts
+++ b/src/kind/pipe.ts
@@ -6,8 +6,8 @@ import { Type, List, Kind } from '..'
  * composes the functions in its input list from left to right, and
  * and applies the resulting type-level function to the second input type.
  *
- * @param {Kind.Kind[]} FX a tuple of type-level functions
- * @param X a type to which a `Kind` can be applied
+ * @param {Kind.Kind[]} FX - a tuple of type-level functions
+ * @param X - a type to which a `Kind` can be applied
  *
  * @see {@link Kind._$compose}
  * The functionality of `_$pipe` is identical to `Kind._$compose`
@@ -49,8 +49,8 @@ interface Pipe_T<FX extends Kind.Kind[]> extends Kind.Kind {
  * composes the functions in its input list from left to right, and
  * and applies the resulting type-level function to the second input type.
  *
- * @param {Kind.Kind[]} FX a tuple of type-level functions
- * @param X a type to which a `Kind` can be applied
+ * @param {Kind.Kind[]} FX - a tuple of type-level functions
+ * @param X - a type to which a `Kind` can be applied
  *
  * @see {@link Kind.Compose}
  * The functionality of `Pipe` is identical to `Kind.Compose`

--- a/src/kind/unapply.ts
+++ b/src/kind/unapply.ts
@@ -6,8 +6,8 @@ import { $, Kind, Type } from '..'
  * b) the original type-level function that was invoked to derive the first input type,
  * and then extracts and returns the applied argument from closure.
  *
- * @param {Kind.Kind} K The target type-level function to unapply.
- * @param {Kind.Kind} F The type-level function that was applied to an argument to derive `K`
+ * @param {Kind.Kind} K - The target type-level function to unapply.
+ * @param {Kind.Kind} F - The type-level function that was applied to an argument to derive `K`
  *
  * Note that `_$unapply` infers the most specific type for the closure argument,
  * whereas `Kind._$inputOf` returns the widest category of arguments accepted by the input function.
@@ -40,8 +40,8 @@ interface Unapply_T<F extends Kind.Kind> extends Kind.Kind {
  * b) the original type-level function that was invoked to derive the first input type,
  * and then extracts and returns the applied argument from closure.
  *
- * @param {Kind.Kind} K The target type-level function to unapply.
- * @param {Kind.Kind} F The type-level function that was applied to an argument to derive `K`
+ * @param {Kind.Kind} K - The target type-level function to unapply.
+ * @param {Kind.Kind} F - The type-level function that was applied to an argument to derive `K`
  *
  * Note that `_$unapply` infers the most specific type for the closure argument,
  * whereas `Kind._$inputOf` returns the widest category of arguments accepted by the input function.

--- a/src/kind/uncurry.ts
+++ b/src/kind/uncurry.ts
@@ -8,8 +8,8 @@ import { $, Kind, Type } from '..'
  * This is syntactic sugar for nested `$` applications. See `$N`, which is the
  * operator shorthand for this function.
  *
- * @param {Kind.Kind} K The type-level function to apply.
- * @param {List.List} X The list of arguments to apply the type-level function to.
+ * @param {Kind.Kind} K - The type-level function to apply.
+ * @param {List.List} X - The list of arguments to apply the type-level function to.
  *
  * This is useful for applying a type-level function that takes many arguments,
  * such as conditionals.
@@ -35,8 +35,8 @@ interface Uncurry_T<K extends Kind.Kind> extends Kind.Kind {
  * This is syntactic sugar for nested `$` applications. See `$N`, which is the
  * operator shorthand for this function.
  *
- * @param {Kind.Kind} K The type-level function to apply.
- * @param {List.List} X The list of arguments to apply the type-level function to.
+ * @param {Kind.Kind} K - The type-level function to apply.
+ * @param {List.List} X - The list of arguments to apply the type-level function to.
  *
  * This is useful for applying a type-level function that takes many arguments,
  * such as conditionals.

--- a/src/list/accumulate.ts
+++ b/src/list/accumulate.ts
@@ -10,9 +10,9 @@ import { $N, Kind, Type, List } from '..'
  * The type-level function input must be a unary, curried `Kind` type as defined in this library, while being of arity 2 when uncurried.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function for a pairwise operation.
- * @param X A list of types. The target of the accumulate operation.
- * @param O A type specifying the initial argument that will be taken by `F`.
+ * @param F - A type-level function for a pairwise operation.
+ * @param X - A list of types. The target of the accumulate operation.
+ * @param O - A type specifying the initial argument that will be taken by `F`.
  *          To use the first element of `X` as the initial argument, simply pass in `Function.Identity`.
  *
  * @example
@@ -61,10 +61,10 @@ interface Accumulate_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * The type-level function input must be a unary, curried `Kind` type as defined in this library, while being of arity 2 if uncurried.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function for a pairwise operation.
- * @param O A type specifying the initial argument that will be taken by `F`.
+ * @param F - A type-level function for a pairwise operation.
+ * @param O - A type specifying the initial argument that will be taken by `F`.
  *          To use first element of `X` as the initial argument, simply pass in `Function.Identity`.
- * @param X A list of types. The target of the accumulate operation.
+ * @param X - A list of types. The target of the accumulate operation.
  *
  * @example
  * For example, we can use `Accumulate` to derive the sum of k = 1 to n for all elements n in a list of natural number types.

--- a/src/list/concat.ts
+++ b/src/list/concat.ts
@@ -6,8 +6,8 @@ import { Type, Kind, List } from '..'
  * It takes in two arguments:
  * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate.
  *
- * @param T A tuple type.
- * @param U A tuple type, or an unknown.
+ * @param T - A tuple type.
+ * @param U - A tuple type, or an unknown.
  * If `U` is not a tuple type, it will be pushed into `T` as its new last element.
  *
  * ## Basic Usage
@@ -46,8 +46,8 @@ interface Concat_T<U extends unknown> extends Kind.Kind {
  * It takes in two arguments:
  * `T`, the tuple to concatenate onto, and `U`, the tuple to concatenate.
  *
- * @param T A tuple type.
- * @param U A tuple type, or an unknown.
+ * @param T - A tuple type.
+ * @param U - A tuple type, or an unknown.
  * If `U` is not a tuple type, it will be pushed into `T` as its new last element.
  *
  * ## Basic Usage

--- a/src/list/filter.ts
+++ b/src/list/filter.ts
@@ -9,8 +9,8 @@ import { $, Type, Kind } from '..'
  * The type-level function input must be a unary, curried `Kind` type as defined in this library.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function that returns a boolean type indicating whether a type should be included in the result.
- * @param X A list of types. The target of the filtering operation.
+ * @param F - A type-level function that returns a boolean type indicating whether a type should be included in the result.
+ * @param X - A list of types. The target of the filtering operation.
  *
  * @example
  * For example, we can use `_$filter` to filter out negative elements from a tuple of numeric types:
@@ -45,8 +45,8 @@ interface Filter_T<F extends Kind.Kind<(x: never) => boolean>>
  * The type-level function input must be a unary, curried `Kind` type as defined in this library.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function that returns a boolean type indicating whether a type should be included in the result.
- * @param X A list of types. The target of the filtering operation.
+ * @param F - A type-level function that returns a boolean type indicating whether a type should be included in the result.
+ * @param X - A list of types. The target of the filtering operation.
  *
  * @example
  * For example, we can define a filter for positive numbers and then apply it to a list:

--- a/src/list/flatten-n.ts
+++ b/src/list/flatten-n.ts
@@ -21,8 +21,8 @@ type _$flattenShallow<
 /**
  * `_$flattenN` is a type-level function that flattens a tuple up to a specified depth level by recursively concatenating nested subtuple elements.
  *
- * @param T The input tuple.
- * @param N Natural number specifying the depth level by which a nested tuple should be flattened.
+ * @param T - The input tuple.
+ * @param N - Natural number specifying the depth level by which a nested tuple should be flattened.
  * If N is greater than or equal to the depth of the input tuple `T`, `T` will be flattened completely.
  *
  * @example
@@ -55,8 +55,8 @@ interface FlattenN_T<N extends Number.Number> extends Kind.Kind {
 /**
  * `FlattenN` is a type-level function that flattens a tuple up to a specified depth level by recursively concatenating nested subtuple elements.
  *
- * @param T The input tuple.
- * @param N Natural number specifying the depth level by which a nested tuple should be flattened.
+ * @param T - The input tuple.
+ * @param N - Natural number specifying the depth level by which a nested tuple should be flattened.
  * If N is greater than or equal to the depth of the input tuple `T`, `T` will be flattened completely.
  *
  * @example

--- a/src/list/flatten.ts
+++ b/src/list/flatten.ts
@@ -3,7 +3,7 @@ import { Kind, List, Type } from '..'
 /**
  * `_$flatten` is a type-level function that completely flattens a tuple by recursively concatenating all nested elements.
  *
- * @param T The input tuple.
+ * @param T - The input tuple.
  *
  * @example
  * ```ts
@@ -27,7 +27,7 @@ export type _$flatten<
 /**
  * `Flatten` is a type-level function that completely flattens a tuple by recursively concatenating all nested elements.
  *
- * @param T The input tuple.
+ * @param T - The input tuple.
  *
  * @example
  * ```ts

--- a/src/list/map.ts
+++ b/src/list/map.ts
@@ -9,8 +9,8 @@ import { $, Type, Kind } from '..'
  * The type-level function input must be a unary, curried `Kind` type as defined in this library.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function that transforms a unary input and returns the result.
- * @param X A list of types. The target of the map operation.
+ * @param F - A type-level function that transforms a unary input and returns the result.
+ * @param X - A list of types. The target of the map operation.
  *
  * @example
  * For example, we can use `_$map` to extract the same property from a list of objects.
@@ -41,8 +41,8 @@ interface Map_T<T extends Kind.Kind> extends Kind.Kind {
  * The type-level function input must be a unary, curried `Kind` type as defined in this library.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function that transforms a unary input and returns the result.
- * @param X A list of types. The target of the map operation.
+ * @param F - A type-level function that transforms a unary input and returns the result.
+ * @param X - A list of types. The target of the map operation.
  *
  * @example
  * For example, we can use `Map` to extract the same property from a list of objects.

--- a/src/list/reduce.ts
+++ b/src/list/reduce.ts
@@ -10,9 +10,9 @@ import { $, Kind, Type, Function } from '..'
  * The type-level function input must be a unary, curried `Kind` type as defined in this library, while being of arity 2 when uncurried.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function for a pairwise operation.
- * @param X A list of types. The target of the reduce operation.
- * @param O A type specifying the initial argument that will be taken by `F`.
+ * @param F - A type-level function for a pairwise operation.
+ * @param X - A list of types. The target of the reduce operation.
+ * @param O - A type specifying the initial argument that will be taken by `F`.
  *          To use the first element of `X` as the initial argument, simply pass in `Function.Identity`.
  *
  * @example
@@ -66,10 +66,10 @@ interface Reduce_T<F extends Kind.Kind<(x: never) => Kind.Kind>>
  * The type-level function input must be a unary, curried `Kind` type as defined in this library, while being of arity 2 if uncurried.
  * @see {@link https://github.com/poteat/hkt-toolbelt/blob/main/docs/guides/custom-kinds.md} for details on how to create a custom kind.
  *
- * @param F A type-level function for a pairwise operation.
- * @param O A type specifying the initial argument that will be taken by `F`.
+ * @param F - A type-level function for a pairwise operation.
+ * @param O - A type specifying the initial argument that will be taken by `F`.
  *          To use first element of `X` as the initial argument, simply pass in `Function.Identity`.
- * @param X A list of types. The target of the reduce operation.
+ * @param X - A list of types. The target of the reduce operation.
  *
  * @example
  * For example, we can use `Reduce` to derive the sum of all elements in a list of numeric types.

--- a/src/list/repeat.ts
+++ b/src/list/repeat.ts
@@ -24,8 +24,8 @@ type _$repeat2<
  * `_$repeat` can handle an output tuple length of up to 2137,
  * which is larger than 999, the maximum recursion depth limit of TypeScript.
  *
- * @param T An unknown type.
- * @param N A natural number.
+ * @param T - An unknown type.
+ * @param N - A natural number.
  * If `N` is not a natural number, returns `never`.
  *
  * ## Basic Usage

--- a/src/list/slice.ts
+++ b/src/list/slice.ts
@@ -7,9 +7,9 @@ import { NaturalNumber, Number, DigitList, Digit, Kind, Type, List } from '..'
  * then `START` and `END`, which respectively specify the inclusive start and exclusive end indices of a slice.
  * Both positive and negative indices are supported, with negative indices being normalized into zero-based indices under the hood.
  * ´´
- * @param T A tuple type.
- * @param START An integer type.
- * @param END An integer type.
+ * @param T - A tuple type.
+ * @param START - An integer type.
+ * @param END - An integer type.
  * A negative index counts back from the end of the input tuple.
  * If `START < 0`, `START + T["length"]` is used.
  * If `END < 0`, `END + T["length"]` is used.
@@ -85,12 +85,12 @@ interface Slice_T<START extends Number.Number> extends Kind.Kind {
  * and `T`, the tuple that is to be sliced.
  * Both positive and negative indices are supported, with negative indices being normalized into zero-based indices under the hood.
  *
- * @param START An integer type.
- * @param END An integer type.
+ * @param START - An integer type.
+ * @param END - An integer type.
  * A negative index counts back from the end of the input tuple.
  * If `START < 0`, `START + T["length"]` is used.
  * If `END < 0`, `END + T["length"]` is used.
- * @param T A tuple type.
+ * @param T - A tuple type.
  *
  * ## Basic Usage
  *

--- a/src/list/splice.ts
+++ b/src/list/splice.ts
@@ -69,12 +69,12 @@ type _$splice2<
  *
  * Both positive and negative indices are supported for `START`. Negative indices will be normalized into zero-based indices.
  *
- * @param T The input tuple.
- * @param START An integer representing the index at which to start splicing.
+ * @param T - The input tuple.
+ * @param START - An integer representing the index at which to start splicing.
  * A negative index counts back from the end of the input tuple.
  * If `START < 0`, `START + T["length"]` is used.
- * @param DEL_COUNT A natural number representing the number of elements to remove from T at the starting index.
- * @param INSERTS An array of elements to insert into T at the starting index.
+ * @param DEL_COUNT - A natural number representing the number of elements to remove from T at the starting index.
+ * @param INSERTS - An array of elements to insert into T at the starting index.
  *
  * ## Usage
  *
@@ -146,12 +146,12 @@ interface Splice_T<START extends Number.Number> extends Kind.Kind {
  *
  * Both positive and negative indices are supported for `START`. Negative indices will be normalized into zero-based indices.
  *
- * @param T The input tuple.
- * @param START An integer representing the index at which to start splicing.
+ * @param T - The input tuple.
+ * @param START - An integer representing the index at which to start splicing.
  * A negative index counts back from the end of the input tuple.
  * If `START < 0`, `START + T["length"]` is used.
- * @param DEL_COUNT A natural number representing the number of elements to remove from T at the starting index.
- * @param INSERTS An array of elements to insert into T at the starting index.
+ * @param DEL_COUNT - A natural number representing the number of elements to remove from T at the starting index.
+ * @param INSERTS - An array of elements to insert into T at the starting index.
  *
  * ## Usage
  *

--- a/src/list/zip.ts
+++ b/src/list/zip.ts
@@ -8,7 +8,7 @@ import { $, Kind, List, Number, NaturalNumber } from '..'
  * The zip operation stops when the shortest sub-array is exhausted.
  * Any remaining items in the longer sub-array are ignored, cutting off the result to the length of the shortest sub-array.
  *
- * @param T An array of types.
+ * @param T - An array of types.
  *
  * @example
  * For example, we can use `_$zip` to perform parallel iteration.
@@ -58,7 +58,7 @@ export type _$zip<
  * The zip operation stops when the shortest sub-array is exhausted.
  * Any remaining items in the longer sub-array are ignored, cutting off the result to the length of the shortest sub-array.
  *
- * @param T An array of arrays.
+ * @param T - An array of arrays.
  *
  * @example
  * For example, we can use `Zip` to perform parallel iteration over multiple sub-arrays.

--- a/src/natural-number-theory/fizzbuzz.ts
+++ b/src/natural-number-theory/fizzbuzz.ts
@@ -5,8 +5,8 @@ import { $, $N, Kind, NaturalNumber, Conditional, List, Function } from '..'
  *
  * i.e. determine whether `N % M === 0`.
  *
- * @param M The number to divide by.
- * @param N The number to check divisibility for.
+ * @param M - The number to divide by.
+ * @param N - The number to check divisibility for.
  *
  * This function 'lifts' the modulo parameters (M and N) out of the pipe via
  * the curry and uncurry operators.
@@ -34,7 +34,7 @@ type DivisibleBy = $N<
  * This function uses the `Conditional.If` type-level function to encode an
  * if-then-else statement.
  *
- * @param N The number to compute the FizzBuzz result for.
+ * @param N - The number to compute the FizzBuzz result for.
  *
  * @example
  * ```ts
@@ -67,7 +67,7 @@ export type FizzBuzz = $N<
  * A type-level function that returns a list of the FizzBuzz results for the
  * first `N` natural numbers, from 1 to `N` inclusive.
  *
- * @param N The number of FizzBuzz results to compute.
+ * @param N - The number of FizzBuzz results to compute.
  *
  * @example
  * ```ts

--- a/src/natural-number/compare.ts
+++ b/src/natural-number/compare.ts
@@ -6,8 +6,8 @@ import { Type, Number, Kind, DigitList, NaturalNumber } from '..'
  * The result will be 1 if `A` is greater than `B`,
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * @param A A natural number type.
- * @param B A natural number type.
+ * @param A - A natural number type.
+ * @param B - A natural number type.
  *
  * @example
  * For example, we can use `_$compare` to compare two natural numbers.
@@ -50,8 +50,8 @@ interface Compare_T<A extends Number.Number> extends Kind.Kind {
  * The result will be 1 if `A` is greater than `B`,
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * @param A A natural number type.
- * @param B A natural number type.
+ * @param A - A natural number type.
+ * @param B - A natural number type.
  *
  * @example
  * For example, we can use `Compare` to compare two natural numbers.

--- a/src/natural-number/is-less-than.ts
+++ b/src/natural-number/is-less-than.ts
@@ -8,8 +8,8 @@ import { Number, NaturalNumber, Kind, Type } from '..'
  * This function works by comparing the ordinal values of `A` and `B`. If `B`
  * has a lower ordinal value than `A`, then `B` is less than `A`.
  *
- * @param A The number to compare against.
- * @param B The number to compare.
+ * @param A - The number to compare against.
+ * @param B - The number to compare.
  */
 export type _$isLessThan<
   /**
@@ -37,8 +37,8 @@ interface IsLessThan_T<A extends Number.Number> extends Kind.Kind {
  * types, `A` and `B`, and returns a boolean indicating whether `B` is less
  * than `A`.
  *
- * @param A The number to compare against.
- * @param B The number to evaluate.
+ * @param A - The number to compare against.
+ * @param B - The number to evaluate.
  *
  * The parameters are ordered such that `IsLessThan` can be partially applied
  * in a coherent manner. That is, we can apply `IsLessThan` to `3`, and have a

--- a/src/natural-number/modulo-by.ts
+++ b/src/natural-number/modulo-by.ts
@@ -4,8 +4,8 @@ import { NaturalNumber, Type, Number, Kind } from '..'
  * `_$moduloBy` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `B` divided by `A`.
  *
- * @param A The number to divide by to calculate the remainder.
- * @param B The numerator.
+ * @param A - The number to divide by to calculate the remainder.
+ * @param B - The numerator.
  *
  * The parameters are reversed from `_$modulo`. This is useful for partial
  * application, i.e. to test divisibility.
@@ -31,8 +31,8 @@ interface ModuloBy_T<A extends number> extends Kind.Kind {
  * `ModuloBy` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `B` divided by `A`.
  *
- * @param A The number to divide by to calculate the remainder.
- * @param B The numerator.
+ * @param A - The number to divide by to calculate the remainder.
+ * @param B - The numerator.
  *
  * The parameters are reversed from `Modulo`. This is useful for partial
  * application, i.e. to test divisibility.

--- a/src/natural-number/modulo.ts
+++ b/src/natural-number/modulo.ts
@@ -4,8 +4,8 @@ import { Type, Number, Kind, DigitList, NaturalNumber } from '..'
  * `Modulo` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `A` divided by `B`.
  *
- * @param A The number to divide.
- * @param B The number to divide by.
+ * @param A - The number to divide.
+ * @param B - The number to divide by.
  */
 export type _$modulo<
   A extends Number.Number,
@@ -26,8 +26,8 @@ interface Modulo_T<A extends Number.Number> extends Kind.Kind {
  * `Modulo` is a type-level function that takes in two natural number types,
  * `A` and `B`, and returns the remainder of `A` divided by `B`.
  *
- * @param A The number to divide.
- * @param B The number to divide by.
+ * @param A - The number to divide.
+ * @param B - The number to divide by.
  *
  * ## Usage Examples
  *

--- a/src/number/absolute.ts
+++ b/src/number/absolute.ts
@@ -5,7 +5,7 @@ import { Number, Type, Kind } from '..'
  *
  * It returns `T` if T >= 0, and `-T` if T < 0.
  *
- * @param T A number type.
+ * @param T - A number type.
  *
  * @example
  * ```ts
@@ -23,7 +23,7 @@ export type _$absolute<T extends Number.Number> =
  *
  * It returns `T` if T >= 0, and `-T` if T < 0.
  *
- * @param T A number type.
+ * @param T - A number type.
  *
  * @example
  * ```ts

--- a/src/number/compare.ts
+++ b/src/number/compare.ts
@@ -61,8 +61,8 @@ export type _$decimalCompare<
  * The result will be 1 if `A` is greater than `B`,
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * @param A A number type.
- * @param B A number type.
+ * @param A - A number type.
+ * @param B - A number type.
  *
  * @example
  * For example, we can use `_$compare` to compare two numbers.
@@ -100,8 +100,8 @@ interface Compare_T<X extends Number.Number> extends Kind.Kind {
  * The result will be 1 if `A` is greater than `B`,
  * 0 if `A` is equal to `B`, and -1 if `A` is less than `B`.
  *
- * @param A A number type.
- * @param B A number type.
+ * @param A - A number type.
+ * @param B - A number type.
  *
  * @example
  * For example, we can use `Compare` to compare two numbers.

--- a/src/number/negate.ts
+++ b/src/number/negate.ts
@@ -5,7 +5,7 @@ import { Number, Type, Kind } from '..'
  *
  * It returns `-T` if T >= 0, and `T` if T < 0.
  *
- * @param T A number type.
+ * @param T - A number type.
  *
  * @example
  * ```ts
@@ -29,7 +29,7 @@ export type _$negate<
  *
  * It returns `-T` if T >= 0, and `T` if T < 0.
  *
- * @param T A number type.
+ * @param T - A number type.
  *
  * @example
  * ```ts


### PR DESCRIPTION
Enables and applies new eslint rule `jsdoc/require hyphen before param description`