### PR TITLE
Meta-programmatic and agentic generation of curried interfaces for custom kinds

### DIFF
--- a/.claude/skills/hkt-util/SKILL.md
+++ b/.claude/skills/hkt-util/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: hkt-util
+description: Author a new hkt-toolbelt utility from a description of its behaviour, or convert an existing runtime function into a type-level kind. Covers the whole path — `_$` base type, curried kind chain via scaffolding/generate-kind.ts, barrel wiring, and Test.Expect witnesses — and refuses conversions whose data domain or effects have no type-level encoding rather than emitting a plausible-looking type that silently disagrees with the function it mirrors. Triggers on /hkt-util, "add a utility for X", "new kind for X", "convert this function to type-level", "type-level version of this".
+---
+
+# hkt-util
+
+Two modes over one procedure.
+
+- **From a description** — the behaviour is stated in prose; write the base type.
+- **From a runtime function** — the behaviour already exists in code; run the
+  convertibility gate, then translate. A conversion that passes the gate is
+  just the first mode with the base type's shape already decided.
+
+## Convertibility gate
+
+Run this before writing anything in the second mode. The type level has no
+floating-point numbers, no effects, and no reference identity, so some functions
+have no faithful encoding at all. **A wrong-but-plausible type is worse than a
+refusal**, because it typechecks and then silently disagrees with the function it
+claims to mirror.
+
+Translates:
+
+| Runtime construct | Type-level counterpart |
+| --- | --- |
+| `Math`, `String.prototype`, `Array.prototype` calls | The corresponding `Number`, `String`, `List` utilities |
+| Integer arithmetic, modulo, parity | `NaturalNumber` and `Integer` utilities |
+| A loop accumulating a result | Structural recursion with an accumulator generic, as in `_$replace` |
+| A callback parameter | A `Kind.Kind` generic, applied with `$` |
+| Parsing a string | `Parser` combinators over template literal types |
+
+Refuse, naming the specific construct:
+
+| Runtime construct | Why |
+| --- | --- |
+| Floating-point arithmetic, `NaN`, `Infinity` | Numbers are digit-encoded; there is no float representation |
+| File, network, `Date.now`, randomness | Types cannot perform effects |
+| Mutable shared state, object identity | The type level is structural — two structurally equal types *are* the same type |
+
+Offer the nearest encodable neighbour when one exists (an integer square root
+rather than a floating-point one). Recursion over caller-supplied input is
+allowed but worth noting, since deep instantiation can exceed the compiler's
+limits and may warrant a `.stress.spec.ts`.
+
+These rows are design analysis rather than tested claims — only the first row is
+exercised by the worked example below.
+
+## Procedure
+
+1. **Read the nearest neighbour.** Find the closest existing utility in the
+   target module (`ls src/<module>/`) and read it with its test. Where it
+   disagrees with anything here, follow the neighbour.
+2. **Write the `_$` base type.** Name it `_$` plus the utility's name with only
+   its first character lowercased — `PadEnd` becomes `_$padEnd`, `HTTPKind`
+   becomes `_$hTTPKind`. Constrain every generic with a meaningful domain, and
+   compose existing utilities rather than reimplementing them.
+3. **Generate the curried chain** instead of hand-writing it:
+   ```sh
+   npx ts-node scaffolding/generate-kind.ts <Name> <arity> [constraint ...]
+   ```
+   One constraint per argument, positional, written as it would appear after
+   `extends`; omit them all to bound everything by `unknown`. Each becomes both
+   the type parameter's bound and that step's `Type._$cast` target.
+4. **Rename the generated type parameters** from `X1`, `X2`, ... to the semantic
+   names the module's neighbours use (`N`, `C`, `S`).
+5. **Add the reified value** where neighbours carry one —
+   `export const camelName = ((...) => ...) as Kind._$reify<Name>`. Not
+   universal: `String.PadEnd` has one, `Number.Min` does not.
+6. **Wire the barrel** — `export * from './<file>'` in the module's `index.ts`,
+   in alphabetical position.
+7. **Write witnesses**, respecting the file-suffix split:
+   - `.test.ts` — run by jest; runtime `it()` cases against the reified value,
+     plus a type-level `<Name>_Spec` tuple.
+   - `.spec.ts` — type-only, compiled by `tsconfig.spec.json`, never executed.
+   - `.stress.spec.ts` — depth and scale cases, `tsconfig.stress.json`.
+
+   Each `Test.Expect` pairs a concrete input with a concrete expected output.
+   When converting, take those pairs from what the runtime function actually
+   returns. **Confirm they bite**: flip one expectation, confirm the compile
+   fails, flip it back. An assertion that cannot fail proves nothing.
+8. **Verify** with `npm test` and `npm run lint-check`. JSDoc follows
+   `style-guide/jsdoc.md`.
+
+## Worked example
+
+Verified end to end — every type below compiles against the library and every
+witness holds.
+
+```ts
+const clamp = (lo: number, hi: number) => (x: number) =>
+  Math.min(hi, Math.max(lo, x))
+```
+
+`Math.min` and `Math.max` have counterparts in `Number`, so the gate passes:
+
+```ts
+import { Number } from '..'
+
+export type _$clamp<
+  LO extends Number.Number,
+  HI extends Number.Number,
+  X extends Number.Number
+> = Number._$min<HI, Number._$max<LO, X>>
+```
+
+Chain from `generate-kind Clamp 3 'Number.Number' 'Number.Number' 'Number.Number'`,
+then witnesses taken from what `clamp(0, 10)` actually returns:
+
+```ts
+type Clamp_Spec = [
+  /**
+   * A value above the upper bound is clamped down to it.
+   */
+  Test.Expect<$<$<$<Clamp, 0>, 10>, 15>, 10>,
+
+  /**
+   * A value below the lower bound is clamped up to it.
+   */
+  Test.Expect<$<$<$<Clamp, 0>, 10>, -3>, 0>,
+
+  /**
+   * A value already within the bounds is returned unchanged.
+   */
+  Test.Expect<$<$<$<Clamp, 0>, 10>, 7>, 7>
+]
+```
+
+Starting from prose instead, the same procedure composes what already exists:
+
+```ts
+import { $, String } from '..'
+
+export type _$isPalindrome<S extends string> =
+  $<String.Reverse, S> extends S ? true : false
+```
+
+And a refusal, which is a complete answer rather than a failure:
+
+```ts
+const jitter = (x: number) => x + Math.random()
+```
+
+`Math.random` cannot be encoded. Types are pure, so there is no type-level
+source of randomness and no type can differ between two instantiations with the
+same arguments. If a deterministic offset would do, `NaturalNumber.Add`
+expresses that instead.
+
+## Related
+
+- `scaffolding/generate-kind.ts` — emits the curried chain; its tests show the
+  chain compiled and behaviour-checked against real kinds.
+- `prompts/make-kind.md`, `make-spec.md`, `make-doc.md` — the single-shot prompt
+  templates this procedure overlaps; `make-kind` predates the generator.
+- `style-guide/jsdoc.md`, `style-guide/tests.md`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   testEnvironment: 'node',
-  roots: ["src"],
+  roots: ["src", "scaffolding"],
   transform: {
     '^.+.tsx?$': ['ts-jest', {}]
   },

--- a/scaffolding/generate-kind.test.ts
+++ b/scaffolding/generate-kind.test.ts
@@ -330,6 +330,18 @@ describe('generateKindInterfaces', () => {
     expect(() => generateKindInterfaces('1Example', 1)).toThrow(TypeError)
   })
 
+  it('rejects a reserved word that identifier characters alone would allow', () => {
+    // `class` and `function` are made of identifier characters but cannot be
+    // declared as interface names, so a chain using one would not parse.
+    expect(() => generateKindInterfaces('class', 1)).toThrow(TypeError)
+    expect(() => generateKindInterfaces('function', 1)).toThrow(TypeError)
+  })
+
+  it('accepts contextual keywords, which are legal in this position', () => {
+    expect(() => generateKindInterfaces('type', 1)).not.toThrow()
+    expect(() => generateKindInterfaces('any', 1)).not.toThrow()
+  })
+
   it('rejects a constraint count that does not match the arity', () => {
     expect(() => generateKindInterfaces('ExampleKind', 3, ['unknown'])).toThrow(
       RangeError

--- a/scaffolding/generate-kind.test.ts
+++ b/scaffolding/generate-kind.test.ts
@@ -1,0 +1,350 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import ts from 'typescript'
+import { generateKindInterfaces, printKindInterfaces } from './generate-kind'
+
+const LIBRARY = path.join(__dirname, '..', 'src').replace(/\\/g, '/')
+
+/**
+ * Typechecks `source` as a standalone module resolving imports against the real
+ * library, and returns the resulting diagnostics.
+ *
+ * Compiling the generator's output is the only check that catches the output
+ * ceasing to be valid hkt-toolbelt code - the string assertions above would
+ * keep passing regardless.
+ *
+ * @param source - Module source to typecheck.
+ */
+function typecheck(source: string): ts.Diagnostic[] {
+  return typecheckAll({ subject: source }).subject
+}
+
+/**
+ * Typechecks several modules in a single program, keyed by name, and returns
+ * each module's diagnostics. Sharing one program keeps the cost of compiling
+ * against the library to a single pass.
+ *
+ * @param sources - Module sources keyed by basename.
+ */
+function typecheckAll(
+  sources: Record<string, string>
+): Record<string, ts.Diagnostic[]> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-kind-'))
+
+  try {
+    const files = Object.entries(sources).map(([name, source]) => {
+      const file = path.join(dir, `${name}.ts`)
+      fs.writeFileSync(file, source)
+      return [name, file] as const
+    })
+
+    const program = ts.createProgram(Object.values(Object.fromEntries(files)), {
+      strict: true,
+      target: ts.ScriptTarget.ES2020,
+      // Matches the root tsconfig; the library uses `replaceAll`.
+      lib: ['lib.es2021.d.ts'],
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      noEmit: true,
+      skipLibCheck: true
+    })
+
+    return Object.fromEntries(
+      files.map(([name, file]) => {
+        const sourceFile = program.getSourceFile(file)!
+        return [
+          name,
+          [
+            ...program.getSyntacticDiagnostics(sourceFile),
+            ...program.getSemanticDiagnostics(sourceFile)
+          ]
+        ]
+      })
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Wraps a generated chain in a module that supplies an implementation and any
+ * trailing assertions.
+ *
+ * @param impl - The `_$` implementation the chain bottoms out in.
+ * @param chain - Generated interface declarations.
+ * @param trailer - Assertions appended after the chain.
+ */
+function moduleWith(impl: string, chain: string, trailer = '') {
+  return [
+    `import { $, Kind, Type, Test } from '${LIBRARY}'`,
+    ``,
+    impl,
+    ``,
+    chain,
+    ``,
+    trailer,
+    `type __used = [Type._$cast<unknown, unknown>, Kind.Kind, $<Kind.Reify, never>]`,
+    ``
+  ].join('\n')
+}
+
+describe('generated chains compile', () => {
+  const chain = printKindInterfaces('Triple', 3).join('\n\n')
+
+  it('is a working Kind that threads every applied argument in order', () => {
+    const diagnostics = typecheck(
+      moduleWith(
+        'type _$triple<A, B, C> = [A, B, C]',
+        chain,
+        [
+          'type Spec = [',
+          '  Test.Expect<$<$<$<Triple, 1>, 2>, 3>, [1, 2, 3]>,',
+          "  Test.Expect<$<$<$<Triple, 'a'>, 'b'>, 'c'>, ['a', 'b', 'c']>,",
+          '  Test.Expect<$<Triple, 1> extends Kind.Kind ? true : false, true>',
+          ']',
+          'type __spec = Spec'
+        ].join('\n')
+      )
+    )
+
+    expect(
+      diagnostics.map((d) =>
+        ts.flattenDiagnosticMessageText(d.messageText, ' ')
+      )
+    ).toEqual([])
+  })
+
+  it('fails the same assertions when the expected type is wrong', () => {
+    const diagnostics = typecheck(
+      moduleWith(
+        'type _$triple<A, B, C> = [A, B, C]',
+        chain,
+        [
+          'type Spec = [Test.Expect<$<$<$<Triple, 1>, 2>, 3>, [1, 2, 4]>]',
+          'type __spec = Spec'
+        ].join('\n')
+      )
+    )
+
+    // Guards the test above: if Test.Expect were inert, that assertion would
+    // pass for any output and prove nothing.
+    expect(diagnostics.length).toBeGreaterThan(0)
+  })
+
+  // Real multi-arity kinds whose `_$` implementations constrain their
+  // parameters, paired with the constraints their hand-written chains declare.
+  const REAL_KINDS = [
+    {
+      kind: 'PadEnd',
+      module: 'string/pad-end',
+      impl: '_$padEnd',
+      constraints: ['Number_.Number', 'string', 'string'],
+      preamble: `import { Number as Number_ } from '${LIBRARY}'`
+    },
+    {
+      kind: 'Assign',
+      module: 'object/assign',
+      impl: '_$assign',
+      constraints: ['PropertyKey', 'unknown', 'Record<PropertyKey, unknown>'],
+      preamble: ''
+    },
+    {
+      kind: 'Replace',
+      module: 'list/replace',
+      impl: '_$replace',
+      constraints: ['unknown', 'unknown', 'unknown[]'],
+      preamble: ''
+    }
+  ]
+
+  /**
+   * Builds the module for one real kind: the generated chain wired to that
+   * kind's existing `_$` implementation.
+   *
+   * @param entry - The real-kind fixture.
+   * @param constrained - Whether to generate with the hand-written constraints.
+   * @param trailer - Assertions appended after the chain.
+   */
+  function realKindModule(
+    entry: (typeof REAL_KINDS)[number],
+    constrained: boolean,
+    trailer = ''
+  ) {
+    return moduleWith(
+      [
+        `import { ${entry.impl} } from '${LIBRARY}/${entry.module}'`,
+        entry.preamble
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      printKindInterfaces(
+        entry.kind,
+        entry.constraints.length,
+        constrained ? entry.constraints : []
+      ).join('\n\n'),
+      trailer
+    )
+  }
+
+  it('satisfies the constrained kinds in this library when given their constraints', () => {
+    const diagnostics = typecheckAll(
+      Object.fromEntries(
+        REAL_KINDS.map((entry) => [entry.kind, realKindModule(entry, true)])
+      )
+    )
+
+    for (const { kind } of REAL_KINDS) {
+      expect(
+        diagnostics[kind].map((d) =>
+          ts.flattenDiagnosticMessageText(d.messageText, ' ')
+        )
+      ).toEqual([])
+    }
+  })
+
+  it('behaves like the hand-written kinds it mirrors', () => {
+    const padEnd = REAL_KINDS[0]
+    const replace = REAL_KINDS[2]
+
+    // The same cases the hand-written specs assert, e.g. string/pad-end.test.ts.
+    const diagnostics = typecheckAll({
+      PadEnd: realKindModule(
+        padEnd,
+        true,
+        [
+          'type Spec = [',
+          "  Test.Expect<$<$<$<PadEnd, 8>, '0'>, 'foo'>, 'foo00000'>,",
+          "  Test.Expect<$<$<$<PadEnd, 4>, '0'>, 'foobar'>, 'foobar'>",
+          ']',
+          'type __spec = Spec'
+        ].join('\n')
+      ),
+      Replace: realKindModule(
+        replace,
+        true,
+        [
+          'type Spec = [Test.Expect<$<$<$<Replace, 1>, 2>, [1, 3, 1]>, [2, 3, 2]>]',
+          'type __spec = Spec'
+        ].join('\n')
+      )
+    })
+
+    for (const name of ['PadEnd', 'Replace']) {
+      expect(
+        diagnostics[name].map((d) =>
+          ts.flattenDiagnosticMessageText(d.messageText, ' ')
+        )
+      ).toEqual([])
+    }
+  })
+
+  it('fails against the same kinds when constraints are omitted', () => {
+    const diagnostics = typecheckAll(
+      Object.fromEntries(
+        REAL_KINDS.map((entry) => [entry.kind, realKindModule(entry, false)])
+      )
+    )
+
+    // Paired control for the two passing cases above: their clean compiles are
+    // attributable to constraint emission, not to the harness. Without
+    // constraints the chain remains a scaffold that needs hand-editing.
+    for (const { kind } of REAL_KINDS) {
+      expect(diagnostics[kind].map((d) => d.code)).toContain(2344)
+    }
+  })
+})
+
+describe('printKindInterfaces', () => {
+  it('generates the documented chain for a four-argument kind', () => {
+    expect(printKindInterfaces('ExampleKind', 4)).toEqual([
+      'export interface ExampleKind extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], unknown>): ExampleKind_T1<typeof x>;\n' +
+        '}',
+      'interface ExampleKind_T1<X1 extends unknown> extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], unknown>): ExampleKind_T2<X1, typeof x>;\n' +
+        '}',
+      'interface ExampleKind_T2<X1 extends unknown, X2 extends unknown> extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], unknown>): ExampleKind_T3<X1, X2, typeof x>;\n' +
+        '}',
+      'interface ExampleKind_T3<X1 extends unknown, X2 extends unknown, X3 extends unknown> extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], unknown>): _$exampleKind<X1, X2, X3, typeof x>;\n' +
+        '}'
+    ])
+  })
+
+  it('collapses a single-argument kind straight to the implementation', () => {
+    expect(printKindInterfaces('ExampleKind', 1)).toEqual([
+      'export interface ExampleKind extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], unknown>): _$exampleKind<typeof x>;\n' +
+        '}'
+    ])
+  })
+
+  it('exports only the entry point of the chain', () => {
+    const printed = printKindInterfaces('ExampleKind', 3)
+
+    expect(printed[0].startsWith('export interface')).toBe(true)
+    expect(printed.slice(1).every((step) => step.startsWith('interface'))).toBe(
+      true
+    )
+  })
+
+  it('lowercases only the first character of the implementation name', () => {
+    expect(printKindInterfaces('HTTPKind', 1)[0]).toContain('_$hTTPKind<')
+  })
+
+  it('threads supplied constraints into the parameter bounds and the casts', () => {
+    expect(
+      printKindInterfaces('PadEnd', 3, ['Number_.Number', 'string', 'string'])
+    ).toEqual([
+      'export interface PadEnd extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], Number_.Number>): PadEnd_T1<typeof x>;\n' +
+        '}',
+      'interface PadEnd_T1<X1 extends Number_.Number> extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], string>): PadEnd_T2<X1, typeof x>;\n' +
+        '}',
+      'interface PadEnd_T2<X1 extends Number_.Number, X2 extends string> extends Kind.Kind {\n' +
+        '    f(x: Type._$cast<this[Kind._], string>): _$padEnd<X1, X2, typeof x>;\n' +
+        '}'
+    ])
+  })
+})
+
+describe('generateKindInterfaces', () => {
+  it('emits one declaration per argument', () => {
+    expect(generateKindInterfaces('ExampleKind', 1)).toHaveLength(1)
+    expect(generateKindInterfaces('ExampleKind', 7)).toHaveLength(7)
+  })
+
+  it('rejects a non-positive or fractional arity', () => {
+    expect(() => generateKindInterfaces('ExampleKind', 0)).toThrow(RangeError)
+    expect(() => generateKindInterfaces('ExampleKind', -1)).toThrow(RangeError)
+    expect(() => generateKindInterfaces('ExampleKind', 1.5)).toThrow(RangeError)
+    expect(() => generateKindInterfaces('ExampleKind', NaN)).toThrow(RangeError)
+  })
+
+  it('rejects a name that is not a valid identifier', () => {
+    expect(() => generateKindInterfaces('', 1)).toThrow(TypeError)
+    expect(() => generateKindInterfaces('Example Kind', 1)).toThrow(TypeError)
+    expect(() => generateKindInterfaces('1Example', 1)).toThrow(TypeError)
+  })
+
+  it('rejects a constraint count that does not match the arity', () => {
+    expect(() => generateKindInterfaces('ExampleKind', 3, ['unknown'])).toThrow(
+      RangeError
+    )
+  })
+
+  it('rejects a constraint that is not a single type expression', () => {
+    expect(() => generateKindInterfaces('ExampleKind', 1, [''])).toThrow(
+      TypeError
+    )
+    expect(() => generateKindInterfaces('ExampleKind', 1, ['}'])).toThrow(
+      TypeError
+    )
+    expect(() =>
+      generateKindInterfaces('ExampleKind', 1, ['number; extra'])
+    ).toThrow(TypeError)
+  })
+})

--- a/scaffolding/generate-kind.ts
+++ b/scaffolding/generate-kind.ts
@@ -26,7 +26,34 @@ const CONTEXT_FILE = ts.createSourceFile(
   ts.ScriptKind.TS
 )
 
-const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+/**
+ * Reports whether `name` can be used as a declared interface name, by asking
+ * the parser rather than approximating with a pattern. A pattern over identifier
+ * characters accepts reserved words such as `class` and `function`, which would
+ * emit a chain that does not parse.
+ *
+ * Contextual keywords like `type` and `any` are accepted, since they are legal
+ * in this position.
+ *
+ * @param name - Candidate kind name.
+ */
+function isDeclarableName(name: string): boolean {
+  const file = ts.createSourceFile(
+    'name.ts',
+    `interface ${name} {}`,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  )
+  const [statement] = file.statements
+
+  return (
+    file.statements.length === 1 &&
+    statement !== undefined &&
+    ts.isInterfaceDeclaration(statement) &&
+    statement.name.text === name
+  )
+}
 
 /**
  * Parses a constraint's type text into a `TypeNode` by wrapping it in a
@@ -235,9 +262,9 @@ function assertValidInputs(
   arity: number,
   constraints: string[]
 ): void {
-  if (!IDENTIFIER_PATTERN.test(name)) {
+  if (!isDeclarableName(name)) {
     throw new TypeError(
-      `kind name must be a valid TypeScript identifier, received: ${JSON.stringify(
+      `kind name must be usable as an interface name, received: ${JSON.stringify(
         name
       )}`
     )

--- a/scaffolding/generate-kind.ts
+++ b/scaffolding/generate-kind.ts
@@ -1,0 +1,330 @@
+import ts, {
+  factory,
+  SyntaxKind,
+  type InterfaceDeclaration,
+  type TypeNode
+} from 'typescript'
+
+/**
+ * The `unknown` keyword node. Used as the type-parameter constraint and the
+ * `Type._$cast` bound wherever no constraint is supplied.
+ */
+const UNKNOWN_NODE = factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword)
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
+
+/**
+ * An empty source file used only as printing context. `printNode` needs a
+ * `SourceFile` to resolve formatting against, but never reads its text when
+ * the node being printed is synthesized.
+ */
+const CONTEXT_FILE = ts.createSourceFile(
+  'generated.ts',
+  '',
+  ts.ScriptTarget.Latest,
+  false,
+  ts.ScriptKind.TS
+)
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+/**
+ * Parses a constraint's type text into a `TypeNode` by wrapping it in a
+ * throwaway type alias. Constraints arrive as text because that keeps call
+ * sites readable - `'Record<PropertyKey, unknown>'` rather than a tree of
+ * factory calls - and the parsed node embeds directly in the synthesized
+ * declarations.
+ *
+ * @param text - The constraint as it would appear after `extends`.
+ */
+function parseConstraint(text: string): TypeNode {
+  const source = `type __C = ${text}`
+  const file = ts.createSourceFile(
+    'constraint.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  )
+  const [statement] = file.statements
+
+  if (
+    file.statements.length !== 1 ||
+    statement === undefined ||
+    !ts.isTypeAliasDeclaration(statement) ||
+    statement.type.end <= statement.type.pos ||
+    source.slice(statement.type.end).trim() !== ''
+  ) {
+    throw new TypeError(
+      `constraint is not a single type expression: ${JSON.stringify(text)}`
+    )
+  }
+
+  return statement.type
+}
+
+/**
+ * Derives the conventional `_$`-prefixed implementation name for a kind by
+ * lowercasing its first character, e.g. `ExampleKind` becomes `_$exampleKind`.
+ *
+ * @param name - The PascalCase name of the kind.
+ */
+function toImplementationName(name: string): string {
+  return `_$${name[0].toLowerCase()}${name.slice(1)}`
+}
+
+/**
+ * Names the type parameter holding the argument applied at the given step.
+ * Sole definition of the `X1`, `X2`, ... scheme - both the declarations and the
+ * references that forward them are derived from this.
+ *
+ * @param index - Zero-based index of the applied argument.
+ */
+function toTypeParameterName(index: number): string {
+  return `X${index + 1}`
+}
+
+/**
+ * Builds the type parameters accumulated by the given step: one parameter per
+ * argument already applied, each bounded by that argument's constraint.
+ *
+ * @param step - Zero-based position in the chain.
+ * @param constraints - Parsed per-argument constraints; missing entries fall
+ *   back to `unknown`.
+ */
+function createAccumulatedTypeParameters(
+  step: number,
+  constraints: TypeNode[]
+) {
+  return Array.from({ length: step }, (_, index) =>
+    factory.createTypeParameterDeclaration(
+      undefined,
+      factory.createIdentifier(toTypeParameterName(index)),
+      constraints[index] ?? UNKNOWN_NODE,
+      undefined
+    )
+  )
+}
+
+/**
+ * Builds a step's `x` parameter: `Type._$cast<this[Kind._], B>`, where `B` is
+ * the constraint of the argument applied at that step (`unknown` when none is
+ * supplied). The hand-written kinds vary this bound per step, which is what
+ * makes an applied argument arrive already narrowed.
+ *
+ * @param bound - The cast target for this step's argument.
+ */
+function createArgumentParameter(bound: TypeNode) {
+  return factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier('x'),
+    undefined,
+    factory.createTypeReferenceNode(
+      factory.createQualifiedName(
+        factory.createIdentifier('Type'),
+        factory.createIdentifier('_$cast')
+      ),
+      [
+        factory.createIndexedAccessTypeNode(
+          factory.createThisTypeNode(),
+          factory.createTypeReferenceNode(
+            factory.createQualifiedName(
+              factory.createIdentifier('Kind'),
+              factory.createIdentifier('_')
+            ),
+            undefined
+          )
+        ),
+        bound
+      ]
+    ),
+    undefined
+  )
+}
+
+/**
+ * Builds the return type of a step's `f` method: the next interface in the
+ * chain, or the `_$` implementation type once every argument has been applied.
+ *
+ * Type arguments are the parameters accumulated so far, plus `typeof x` for the
+ * argument being applied at this step.
+ *
+ * @param step - Zero-based position in the chain.
+ * @param arity - Total number of arguments the kind accepts.
+ * @param name - The PascalCase name of the kind.
+ */
+function createStepReturnType(step: number, arity: number, name: string) {
+  const isFinalStep = step === arity - 1
+
+  return factory.createTypeReferenceNode(
+    factory.createIdentifier(
+      isFinalStep ? toImplementationName(name) : `${name}_T${step + 1}`
+    ),
+    [
+      ...Array.from({ length: step }, (_, index) =>
+        factory.createTypeReferenceNode(
+          factory.createIdentifier(toTypeParameterName(index)),
+          undefined
+        )
+      ),
+      factory.createTypeQueryNode(factory.createIdentifier('x'), undefined)
+    ]
+  )
+}
+
+/**
+ * Builds the `step`-th interface of a curried kind chain.
+ *
+ * Step `0` is the exported entry point, named `name`. Intermediate steps are
+ * named `${name}_T${step}` and are not exported, since they are only reachable
+ * through the entry point.
+ *
+ * @param step - Zero-based position in the chain.
+ * @param arity - Total number of arguments the kind accepts.
+ * @param name - The PascalCase name of the kind.
+ * @param constraints - Parsed per-argument constraints; missing entries fall
+ *   back to `unknown`.
+ */
+function createChainStep(
+  step: number,
+  arity: number,
+  name: string,
+  constraints: TypeNode[]
+): InterfaceDeclaration {
+  const typeParameters = createAccumulatedTypeParameters(step, constraints)
+
+  const extendsKind = factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+    factory.createExpressionWithTypeArguments(
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier('Kind'),
+        factory.createIdentifier('Kind')
+      ),
+      undefined
+    )
+  ])
+
+  const method = factory.createMethodSignature(
+    undefined,
+    factory.createIdentifier('f'),
+    undefined,
+    undefined,
+    [createArgumentParameter(constraints[step] ?? UNKNOWN_NODE)],
+    createStepReturnType(step, arity, name)
+  )
+
+  return factory.createInterfaceDeclaration(
+    step === 0 ? [factory.createToken(SyntaxKind.ExportKeyword)] : undefined,
+    factory.createIdentifier(step === 0 ? name : `${name}_T${step}`),
+    typeParameters.length > 0 ? typeParameters : undefined,
+    [extendsKind],
+    [method]
+  )
+}
+
+/**
+ * Validates the inputs shared by both public entry points.
+ *
+ * @param name - The PascalCase name of the kind.
+ * @param arity - Total number of arguments the kind accepts.
+ * @param constraints - Per-argument constraint texts; either empty or exactly
+ *   one per argument.
+ */
+function assertValidInputs(
+  name: string,
+  arity: number,
+  constraints: string[]
+): void {
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    throw new TypeError(
+      `kind name must be a valid TypeScript identifier, received: ${JSON.stringify(
+        name
+      )}`
+    )
+  }
+
+  if (!Number.isInteger(arity) || arity < 1) {
+    throw new RangeError(
+      `arity must be a positive integer, received: ${String(arity)}`
+    )
+  }
+
+  if (constraints.length > 0 && constraints.length !== arity) {
+    throw new RangeError(
+      `expected ${arity} constraints, one per argument, received ${constraints.length}`
+    )
+  }
+}
+
+/**
+ * Generates the chain of interface declarations implementing a curried kind of
+ * the given arity.
+ *
+ * The chain applies one argument per step, threading each applied argument
+ * forward as a type parameter, and bottoms out in a reference to the
+ * hand-written `_$` implementation type.
+ *
+ * @param name - The PascalCase name of the kind, e.g. `ExampleKind`.
+ * @param arity - Total number of arguments the kind accepts. Must be >= 1.
+ * @param constraints - Per-argument constraint type texts, one per argument.
+ *   Each becomes both the bound on its accumulated type parameter and the
+ *   `Type._$cast` target at the step that applies the argument. Omit to bound
+ *   everything by `unknown`.
+ */
+export function generateKindInterfaces(
+  name: string,
+  arity: number,
+  constraints: string[] = []
+): InterfaceDeclaration[] {
+  assertValidInputs(name, arity, constraints)
+
+  const constraintNodes = constraints.map(parseConstraint)
+
+  return Array.from({ length: arity }, (_, step) =>
+    createChainStep(step, arity, name, constraintNodes)
+  )
+}
+
+/**
+ * Generates a curried kind chain and prints each declaration to source text.
+ *
+ * @param name - The PascalCase name of the kind, e.g. `ExampleKind`.
+ * @param arity - Total number of arguments the kind accepts. Must be >= 1.
+ * @param constraints - Per-argument constraint type texts; see
+ *   {@link generateKindInterfaces}.
+ */
+export function printKindInterfaces(
+  name: string,
+  arity: number,
+  constraints: string[] = []
+): string[] {
+  return generateKindInterfaces(name, arity, constraints).map((node) =>
+    printer.printNode(ts.EmitHint.Unspecified, node, CONTEXT_FILE)
+  )
+}
+
+/**
+ * Prints a generated chain to stdout.
+ *
+ * @param argv - Positional arguments: the kind name, the arity, then optional
+ *   per-argument constraint type texts.
+ */
+function main(argv: string[]): void {
+  const [name, rawArity, ...constraints] = argv
+
+  if (name === undefined || rawArity === undefined) {
+    console.error(
+      'usage: generate-kind <PascalCaseName> <arity> [constraint ...]'
+    )
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    printKindInterfaces(name, Number(rawArity), constraints).join('\n\n')
+  )
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+}

--- a/scaffolding/skill-examples.test.ts
+++ b/scaffolding/skill-examples.test.ts
@@ -20,7 +20,9 @@ const SKILL = path.join(
  * @param markdown - Document text.
  */
 function typescriptBlocks(markdown: string): string[] {
-  return [...markdown.matchAll(/```ts\n([\s\S]*?)```/g)].map((match) =>
+  // Tolerates CRLF, since a checkout with `core.autocrlf` enabled would
+  // otherwise find no blocks at all and fail on unchanged content.
+  return [...markdown.matchAll(/```ts\r?\n([\s\S]*?)```/g)].map((match) =>
     match[1].trimEnd()
   )
 }
@@ -111,6 +113,16 @@ describe('hkt-util skill examples', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  it('finds the same blocks when the document has CRLF line endings', () => {
+    const document = fs.readFileSync(SKILL, 'utf-8')
+    const crlf = document.replace(/\r?\n/g, '\r\n')
+
+    expect(typescriptBlocks(crlf)).toHaveLength(
+      typescriptBlocks(document).length
+    )
+    expect(typescriptBlocks(crlf).length).toBeGreaterThan(0)
   })
 
   it('witnesses match what the runtime function in the skill returns', () => {

--- a/scaffolding/skill-examples.test.ts
+++ b/scaffolding/skill-examples.test.ts
@@ -1,0 +1,142 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import ts from 'typescript'
+import { printKindInterfaces } from './generate-kind'
+
+const LIBRARY = path.join(__dirname, '..', 'src').replace(/\\/g, '/')
+const SKILL = path.join(
+  __dirname,
+  '..',
+  '.claude',
+  'skills',
+  'hkt-util',
+  'SKILL.md'
+)
+
+/**
+ * Extracts the TypeScript fenced blocks from a markdown document, in order.
+ *
+ * @param markdown - Document text.
+ */
+function typescriptBlocks(markdown: string): string[] {
+  return [...markdown.matchAll(/```ts\n([\s\S]*?)```/g)].map((match) =>
+    match[1].trimEnd()
+  )
+}
+
+/**
+ * Finds the single extracted block containing `marker`, failing loudly when the
+ * document no longer contains exactly one such block - a rename should surface
+ * here rather than silently reducing coverage.
+ *
+ * @param blocks - Extracted blocks.
+ * @param marker - Substring identifying the wanted block.
+ */
+function blockContaining(blocks: string[], marker: string): string {
+  const matches = blocks.filter((block) => block.includes(marker))
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one block containing ${JSON.stringify(marker)}, found ${matches.length}`
+    )
+  }
+
+  return matches[0]
+}
+
+/** Drops import statements so blocks can share one assembled module. */
+function withoutImports(block: string): string {
+  return block
+    .split('\n')
+    .filter((line) => !line.startsWith('import '))
+    .join('\n')
+}
+
+const blocks = typescriptBlocks(fs.readFileSync(SKILL, 'utf-8'))
+
+describe('hkt-util skill examples', () => {
+  it('type-level examples compile and their witnesses hold', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-examples-'))
+
+    try {
+      const file = path.join(dir, 'subject.ts')
+
+      // Assembled exactly as the skill instructs: the base type it shows, the
+      // chain its `generate-kind` invocation produces, then its witnesses.
+      fs.writeFileSync(
+        file,
+        [
+          `import { $, Kind, Type, Test, Number, String } from '${LIBRARY}'`,
+          ``,
+          withoutImports(blockContaining(blocks, '_$clamp')),
+          ``,
+          printKindInterfaces('Clamp', 3, [
+            'Number.Number',
+            'Number.Number',
+            'Number.Number'
+          ]).join('\n\n'),
+          ``,
+          blockContaining(blocks, 'Clamp_Spec'),
+          ``,
+          withoutImports(blockContaining(blocks, '_$isPalindrome')),
+          ``,
+          `type __used = [`,
+          `  Clamp_Spec,`,
+          `  _$isPalindrome<'racecar'>,`,
+          `  Type._$cast<unknown, unknown>,`,
+          `  Kind.Kind,`,
+          `  String.Reverse`,
+          `]`,
+          ``
+        ].join('\n')
+      )
+
+      const program = ts.createProgram([file], {
+        strict: true,
+        target: ts.ScriptTarget.ES2020,
+        lib: ['lib.es2021.d.ts'],
+        module: ts.ModuleKind.CommonJS,
+        esModuleInterop: true,
+        noEmit: true,
+        skipLibCheck: true
+      })
+
+      expect(
+        [
+          ...program.getSyntacticDiagnostics(),
+          ...program.getSemanticDiagnostics()
+        ].map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '))
+      ).toEqual([])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('witnesses match what the runtime function in the skill returns', () => {
+    // The skill's central discipline is that a conversion's witnesses come from
+    // the original function's actual output. That only holds if the two agree,
+    // so both sides are taken from the document rather than restated here.
+    const runtime = ts.transpileModule(
+      withoutImports(blockContaining(blocks, 'Math.min')),
+      { compilerOptions: { target: ts.ScriptTarget.ES2020 } }
+    ).outputText
+
+    const clamp = new Function(`${runtime}; return clamp`)() as (
+      lo: number,
+      hi: number
+    ) => (x: number) => number
+
+    const witnesses = [
+      ...blockContaining(blocks, 'Clamp_Spec').matchAll(
+        /Test\.Expect<\$<\$<\$<Clamp, (-?\d+)>, (-?\d+)>, (-?\d+)>, (-?\d+)>/g
+      )
+    ].map((m) => m.slice(1, 5).map(Number) as [number, number, number, number])
+
+    expect(witnesses).toHaveLength(3)
+
+    for (const [lo, hi, x, expected] of witnesses) {
+      expect(clamp(lo, hi)(x)).toBe(expected)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Defining a custom kind of arity N means hand-writing the `_T1`/`_T2`/... interface chain, mechanical boilerplate that 15 modules in `src/` each carry a copy of. #61 asked for it to be generated.

- **`scaffolding/generate-kind.ts`** emits the chain for any arity through the TypeScript compiler API — naming, ordering, type-parameter threading, signatures, and, given per-argument constraint texts, the bound on each type parameter and each step's `Type._$cast` target. Imports and module emission are follow-ups.
- **`.claude/skills/hkt-util/SKILL.md`** covers the step upstream of both the generator and `prompts/make-kind`: reaching the `_$` base type from a description or an existing runtime function, then through the chain, barrel, and witnesses. Conversions carry a refusal path, since floats, effects, and reference identity have no type-level encoding and a plausible type for one of them typechecks while silently disagreeing with the function it mirrors. New top-level directory — a judgement call worth flagging.

A macro framework was the alternative, moving code-generating-code into a dedicated system. `ts-macros`, the candidate evaluated, has a TypeScript peer range ending at `5.6.x` against this repo's `^5.6.2`; for a library tracking the type system closely, a build-time dependency capping the TypeScript version is the wrong trade. The generator is small enough to port later.

Stacked on #100, which fixes the unrelated `lint-check` failure on `main`; this diff is the five files above it.

## Usage

Two entry points: the generator alone when a base type already exists, and the skill when it does not.

### The generator

One constraint per argument, positional, as it would appear after `extends`; omit them all to bound everything by `unknown`:

```sh
npx ts-node scaffolding/generate-kind.ts PadEnd 3 'Number_.Number' string string
```

```ts
export interface PadEnd extends Kind.Kind {
    f(x: Type._$cast<this[Kind._], Number_.Number>): PadEnd_T1<typeof x>;
}

interface PadEnd_T1<X1 extends Number_.Number> extends Kind.Kind {
    f(x: Type._$cast<this[Kind._], string>): PadEnd_T2<X1, typeof x>;
}

interface PadEnd_T2<X1 extends Number_.Number, X2 extends string> extends Kind.Kind {
    f(x: Type._$cast<this[Kind._], string>): _$padEnd<X1, X2, typeof x>;
}
```

Pinned verbatim by the case › `threads supplied constraints into the parameter bounds and the casts`.

The chain bottoms out in `_$` plus the kind's name with its first character lowercased (`PadEnd` → `_$padEnd`), matching the hand-written kinds. Paste it into a module defining or importing that type, alongside `Kind`, `Type`, and whatever the constraints reference. Programmatically, `generateKindInterfaces(name, arity, constraints?)` returns `ts.InterfaceDeclaration[]` and `printKindInterfaces` the source texts.

### The skill

`.claude/skills/hkt-util/SKILL.md` is picked up by Claude Code inside this repo and invoked as `/hkt-util`. It runs the whole path the generator sits in the middle of: read the nearest existing utility in the target module, write the `_$` base type, generate the chain, rename the generated `X1`/`X2` to the module's semantic names, add a reified value where neighbours carry one, wire the barrel, then write witnesses in whichever of `.test.ts` / `.spec.ts` / `.stress.spec.ts` the file-suffix split calls for.

Given a runtime function instead of a description, it first decides whether one exists at all. Floating-point arithmetic, effects, and reference identity have no type-level encoding, so it names the offending construct and stops rather than emitting a type that typechecks and then disagrees with the function it mirrors.

Its own examples are executable — see `skill-examples.test.ts` under Validation Run — and #101 is its first end-to-end output, where following it produced `Number.Clamp` and its neighbour overrode two of the skill's own defaults, which is the deferral its first step asks for.

## 🧪 Validation Run

**Verdict:** ✅ proven — generated chains compile against this library's real `_$` implementations and compute what the hand-written kinds compute
head `6acb581` · evidence: `scaffolding/generate-kind.test.ts`, `scaffolding/skill-examples.test.ts`

No hosted run covers this head: the workflow's `pull_request: branches: [main]` filter skips PRs based on a side branch, so the runs below are local captures rather than a run page. They become re-runnable in CI once #100 merges and the base retargets.

<details>
<summary><code>npx jest scaffolding/ --verbose</code> — 17 passed</summary>

```
✓ is a working Kind that threads every applied argument in order 
✓ fails the same assertions when the expected type is wrong 
✓ satisfies the constrained kinds in this library when given their constraints 
✓ behaves like the hand-written kinds it mirrors 
✓ fails against the same kinds when constraints are omitted 
✓ generates the documented chain for a four-argument kind 
✓ collapses a single-argument kind straight to the implementation
✓ exports only the entry point of the chain 
✓ lowercases only the first character of the implementation name 
✓ threads supplied constraints into the parameter bounds and the casts 
✓ emits one declaration per argument 
✓ rejects a non-positive or fractional arity 
✓ rejects a name that is not a valid identifier 
✓ rejects a constraint count that does not match the arity 
✓ rejects a constraint that is not a single type expression 
✓ type-level examples compile and their witnesses hold 
✓ witnesses match what the runtime function in the skill returns 
Test Suites: 2 passed, 2 total
Tests:       17 passed, 17 total
```
</details>

Two falsifiers. **A chain that doesn't compile against a real implementation**, and **a chain that compiles but computes something other than the kind it replaces** — the first closed by generating `PadEnd`, `Assign`, and `Replace` with their hand-written constraints and compiling against their existing `_$` types, the second by putting the generated `PadEnd` and `Replace` through the same `Test.Expect` cases as the hand-written specs.

Neither is self-certifying, so both have negative controls: one mutates an expected type, one omits constraints and requires `TS2344`. Below, the generator itself is mutated — the per-step `Type._$cast` bound forced back to `unknown` — which kills exactly the four constraint-dependent cases while both controls stay green, since a control that dies alongside what it guards is not a control:

<details>
<summary>Same command with <code>constraints[step] ?? UNKNOWN_NODE</code> → <code>UNKNOWN_NODE</code></summary>

```
✓ is a working Kind that threads every applied argument in order 
✓ fails the same assertions when the expected type is wrong 
✕ satisfies the constrained kinds in this library when given their constraints 
✕ behaves like the hand-written kinds it mirrors 
✓ fails against the same kinds when constraints are omitted 
✓ generates the documented chain for a four-argument kind 
✓ collapses a single-argument kind straight to the implementation 
✓ exports only the entry point of the chain 
✓ lowercases only the first character of the implementation name
✕ threads supplied constraints into the parameter bounds and the casts 
✓ emits one declaration per argument 
✓ rejects a non-positive or fractional arity 
✓ rejects a name that is not a valid identifier 
✓ rejects a constraint count that does not match the arity 
✓ rejects a constraint that is not a single type expression 
✕ type-level examples compile and their witnesses hold 
✓ witnesses match what the runtime function in the skill returns 
Tests:       4 failed, 13 passed, 17 total
```
</details>

The tests compile through `ts.createProgram` rather than asserting printed text, which keeps passing when output stops being valid hkt-toolbelt code. `skill-examples.test.ts` applies the same treatment to the skill's documentation: it extracts the document's own TypeScript blocks, compiles them, then transpiles the runtime function it shows and asserts it returns what the documented witnesses expect.

One finding not visible in the diff: of the 15 hand-written chains, 11 export only the entry point and 4 export intermediates, so the generator follows the majority. Declaration order is cosmetic, since interfaces hoist.

## Follow-ups

- Import the submodules that constraint texts reference (currently trusted to match the consuming module's imports).
- Inline a stringified `_$` implementation, or keep emitting only the reference (current; more readable).
- Emit to a user-specified path rather than stdout.
- Optional semantic type-parameter names (`N`, `C`, `S`) instead of `X1`, `X2`, ...
- No value-level `as Kind._$reify<...>` companion; #61 does not ask for it.
- `prompts/make-kind.md` asks a model to hand-produce the chain `generate-kind` now emits deterministically; retiring or cross-referencing it is the prompt set owner's call.

Refs #61.

## Test plan

- [x] `npm test` — 169 suites, 412 tests, all passing (adds 17)
- [x] `npm run build` and `npm run lint-check` — clean, 0 errors
- [ ] Hosted CI at this head — skipped by the `branches: [main]` filter while based on a side branch; last ran green at `2ec981ab`, resumes when #100 merges
