### PR TITLE
feat: Add `Type.Assert` HKT that implements behavior of TypeScript `as` assertions, and add `Type.Cast` improvements

### DIFF
--- a/src/type/assert.spec.ts
+++ b/src/type/assert.spec.ts
@@ -1,0 +1,23 @@
+import { Test, Type } from '..'
+
+type Assert_Spec = [
+  /**
+   * Can cast a type to itself.
+   */
+  Test.Expect<Type._$assert<true, true>, true>,
+
+  /**
+   * Can cast a type to a subtype.
+   */
+  Test.Expect<Type._$assert<boolean, true>, true>,
+
+  /**
+   * Can cast a type to a supertype.
+   */
+  Test.Expect<Type._$assert<true, boolean>, boolean>,
+
+  /**
+   * Returns `never` if the types are not related.
+   */
+  Test.Expect<Type._$assert<boolean, 0>, never>
+]

--- a/src/type/assert.ts
+++ b/src/type/assert.ts
@@ -1,0 +1,43 @@
+import { Kind } from '..'
+
+/**
+ * `_$assert` is a generic type that casts a type `T` to a type `U`, but only if `U` is a narrower or wider version of `T`.
+ * If an impossible coercion to an unrelated type is attempted, it returns `never`.
+ *
+ * This behavior is modeled after TypeScript's type assertion using the `as` operator.
+ * @see {@link Type._$cast} for a more permissive version of this type that only performs downcasts or coercions to unrelated types.
+ *
+ * @template T - The type to assert.
+ * @template U - The type to assert to.
+ *
+ * @example
+ * type T0 = _$assert<true, true> // true
+ * type T1 = _$assert<boolean, true> // true
+ * type T2 = _$assert<true, boolean> // boolean
+ * type T3 = _$assert<boolean, 0> // never
+ */
+export type _$assert<T, U> = [T] extends [U] ? U : [U] extends [T] ? U : never
+
+interface Assert_T<T> extends Kind.Kind {
+  f(x: this[Kind._]): _$assert<typeof x, T>
+}
+
+/**
+ * `Assert` is a type-level function that casts a type `T` to a type `U`, but only if `U` is a more or less specific version of `T`.
+ * If an impossible coercion to an unrelated type is attempted, it returns `never`.
+ *
+ * This behavior is modeled after TypeScript's type assertion using the `as` operator.
+ * @see {@link Type._$cast} for a more permissive version of this function that only performs downcasts or coercions to unrelated types.
+ *
+ * @template T - The type to assert.
+ * @template U - The type to assert to.
+ *
+ * @example
+ * type T0 = $<$<Assert, true>, true> // true
+ * type T1 = $<$<Assert, boolean>, true> // true
+ * type T2 = $<$<Assert, true>, boolean> // boolean
+ * type T3 = $<$<Assert, boolean>, 0> // never
+ */
+export interface Assert extends Kind.Kind {
+  f(x: this[Kind._]): Assert_T<typeof x>
+}

--- a/src/type/cast.spec.ts
+++ b/src/type/cast.spec.ts
@@ -14,5 +14,10 @@ type Cast_Spec = [
   /**
    * Casting to a supertype keeps the type narrow.
    */
-  Test.Expect<Type._$cast<true, boolean>, true>
+  Test.Expect<Type._$cast<true, boolean>, true>,
+
+  /**
+   * Can coercively cast a type to an unrelated type.
+   */
+  Test.Expect<Type._$cast<boolean, 0>, 0>
 ]

--- a/src/type/cast.ts
+++ b/src/type/cast.ts
@@ -1,7 +1,8 @@
 import { Kind } from '..'
 
 /**
- * `_$cast` is a type-level function that casts a type `T` to a type `U`.
+ * `_$cast` is a generic type that coercively downcasts a type `T` to a type `U`.
+ * Returns the narrower out of the two types. If the two types are unrelated, returns `U`.
  *
  * @template T - The type to cast.
  * @template U - The type to cast to.
@@ -10,6 +11,7 @@ import { Kind } from '..'
  * type T0 = _$cast<true, true> // true
  * type T1 = _$cast<boolean, true> // true
  * type T2 = _$cast<true, boolean> // true
+ * type T3 = _$cast<boolean, 0> // 0
  */
 export type _$cast<T, U> = [T] extends [U] ? T : U
 
@@ -18,7 +20,8 @@ interface Cast_T<T> extends Kind.Kind {
 }
 
 /**
- * `Cast` is a type-level function that casts a type `T` to a type `U`.
+ * `Cast` is a type-level function that coercively downcasts a type `T` to a type `U`.
+ * Returns the narrower out of the two types. If the two types are unrelated, returns `U`.
  *
  * @template T - The type to cast.
  * @template U - The type to cast to.
@@ -27,6 +30,7 @@ interface Cast_T<T> extends Kind.Kind {
  * type T0 = $<$<Cast, true>, true> // true
  * type T1 = $<$<Cast, boolean>, true> // true
  * type T2 = $<$<Cast, true>, boolean> // true
+ * type T3 = $<$<Cast, boolean>, 0> // 0
  */
 export interface Cast extends Kind.Kind {
   f(x: this[Kind._]): Cast_T<typeof x>

--- a/src/type/cast.ts
+++ b/src/type/cast.ts
@@ -11,7 +11,7 @@ import { Kind } from '..'
  * type T1 = _$cast<boolean, true> // true
  * type T2 = _$cast<true, boolean> // true
  */
-export type _$cast<T, U> = T extends U ? T : U
+export type _$cast<T, U> = [T] extends [U] ? T : U
 
 interface Cast_T<T> extends Kind.Kind {
   f(x: this[Kind._]): _$cast<typeof x, T>

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,3 +1,4 @@
+export * from './assert'
 export * from './cast'
 export * from './display'
 export * from './infer'


### PR DESCRIPTION
- Adds new HKT `Type.Assert`, which performs type casting to related subtypes and supertypes, but returns `never` for impossible coercions. 
- `Type._$cast` is now non-distributive for union input params.
  - No functional change, but makes the intent of the implementation a bit clearer.
  - Rough proof of equivalence:
```ts
1. CastDistributive<T, U> = T extends U ? T : U
CastDistributive<A | B, U>
<=> | (A extends U ? A : U)
    | (B extends U ? B : U)

if (A extends U && B extends U)
  <=> A | B

if (A extends U && B not extends U)
  <=> A | U
  <=> U

if (A not extends U && B not extends U)
  <=> U | U
  <=> U

2. CastNonDistributive<T, U> = [T] extends [U] ? T : U
CastNonDistributive<A | B, U>
<=> [A | B] extends [U] ? A | B : U

if (A extends U && B extends U)
  <=> A | B

if (A extends U && B not extends U)
  => A | B not extends U
  ∴ U

if (A not extends U && B not extends U)
  => A | B not extends U
  ∴ U
```
